### PR TITLE
[WIP] Get the infra to the point where it cleanly plans/applies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.plan
 *.tfvars
 .DS_Store
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 include functions.Makefile
 include formatting.Makefile
 
+export AWS_PROFILE = wellcomedigitalworkflow
+
 tf-plan:
-	$(call terraform_plan,$(ROOT)/terraform,false)
+	$(call terraform_plan,terraform,false)
 
 tf-apply:
-	$(call terraform_apply,$(ROOT)/terraform)
+	$(call terraform_apply,terraform)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,25 @@
 
 [![Build Status](https://travis-ci.org/wellcometrust/archivematica.svg?branch=master)](https://travis-ci.org/wellcometrust/archivematica)
 
-Dockerfiles & Terraform required to run Archivematica on AWS ECS. 
+Dockerfiles & Terraform required to run Archivematica on AWS ECS.
+
+## Getting credentials
+
+This assumes you already have credentials for the `wellcomedigitalplatform` account.
+
+You need credentials for the workflow account.
+
+1.  Download the script for issuing temporary credentials: <https://github.com/alexwlchan/junkdrawer/blob/master/aws/issue_temporary_credentials.py>
+
+2.  Run the script to set up credentials:
+
+    ```console
+    $ python issue_temporary_credentials.py --account_id=299497370133 --role_name=platform-team-assume-role --account_name=wellcomedigitalworkflow
+    ```
+
+You can then run `make tf-plan` and `make tf-apply` like normal.
+
+The credentials will expire after 60 minutes; re-run the script to get a fresh set.
+
+Note: we cannot use AssumeRole in the Terraform provider because we also need it when retrieving the Terraform vars file from the S3 bucket in the workflow account.
+Later we might consider pushing this inside our wrapper.

--- a/functions.Makefile
+++ b/functions.Makefile
@@ -1,69 +1,7 @@
 ROOT = $(shell git rev-parse --show-toplevel)
 
-ifndef UPTODATE_GIT_DEFINED
+export TFVARS_BUCKET = wellcomecollection-workflow-infra
+export TFVARS_KEY    = terraform/workflow.tfvars
+export TFPLAN_BUCKET = wellcomecollection-workflow-infra
 
-# This target checks if you're up-to-date with the current master.
-# This avoids problems where Terraform goes backwards or breaks
-# already-applied changes.
-#
-# Consider the following scenario:
-#
-#     * --- * --- X --- Z                 master
-#                  \
-#                   Y --- Y --- Y         feature branch
-#
-# We cut a feature branch at X, then applied commits Y.  Meanwhile master
-# added commit Z, and ran `terraform apply`.  If we run `terraform apply` on
-# the feature branch, this would revert the changes in Z!  We'd rather the
-# branches looked like this:
-#
-#     * --- * --- X --- Z                 master
-#                        \
-#                         Y --- Y --- Y   feature branch
-#
-# So that the commits in the feature branch don't unintentionally revert Z.
-#
-uptodate-git:
-	@git fetch origin
-	@if ! git merge-base --is-ancestor origin/master HEAD; then \
-		echo "You need to be up-to-date with master before you can continue!"; \
-		exit 1; \
-	fi
-
-UPTODATE_GIT_DEFINED = true
-
-endif
-
-# Run a 'terraform plan' step.
-#
-# Args:
-#   $1 - Path to the Terraform directory.
-#	$2 - true/false: is this a public-facing stack?
-#
-define terraform_plan
-	make uptodate-git
-	AWS_PROFILE="wellcomedigitalworkflow" $(ROOT)/docker_run.py --aws -- \
-		--volume $(1):/data \
-		--env OP=plan \
-		--env GET_TFVARS=true \
-		--env IS_PUBLIC_FACING=$(2) \
-		--env BUCKET_NAME=wellcomecollection-workflow-infra \
-		--env OBJECT_KEY=terraform/workflow.tfvars \
-		wellcome/terraform_wrapper:latest
-endef
-
-
-# Run a 'terraform apply' step.
-#
-# Args:
-#   $1 - Path to the Terraform directory.
-#
-define terraform_apply
-	make uptodate-git
-	AWS_PROFILE="wellcomedigitalworkflow" $(ROOT)/docker_run.py --aws -- \
-		--volume $(1):/data \
-		--env OP=apply \
-		--env BUCKET_NAME=wellcomecollection-workflow-infra \
-		--env OBJECT_KEY=terraform/workflow.tfvars \
-		wellcome/terraform_wrapper:latest
-endef
+include $(ROOT)/makefiles/terraform.Makefile

--- a/makefiles/terraform.Makefile
+++ b/makefiles/terraform.Makefile
@@ -1,0 +1,80 @@
+##############################################################################
+#
+# This is a copy of `terraform.Makefile`, the main copy of which is in the
+# wellcometrust/platform repo.
+#
+# If you need to make changes: edit that, and copy the changes here.
+#
+##############################################################################
+
+TERRAFORM_WRAPPER_IMAGE = wellcome/terraform_wrapper:13
+
+ifndef UPTODATE_GIT_DEFINED
+
+# This target checks if you're up-to-date with the current master.
+# This avoids problems where Terraform goes backwards or breaks
+# already-applied changes.
+#
+# Consider the following scenario:
+#
+#     * --- * --- X --- Z                 master
+#                  \
+#                   Y --- Y --- Y         feature branch
+#
+# We cut a feature branch at X, then applied commits Y.  Meanwhile master
+# added commit Z, and ran `terraform apply`.  If we run `terraform apply` on
+# the feature branch, this would revert the changes in Z!  We'd rather the
+# branches looked like this:
+#
+#     * --- * --- X --- Z                 master
+#                        \
+#                         Y --- Y --- Y   feature branch
+#
+# So that the commits in the feature branch don't unintentionally revert Z.
+#
+uptodate-git:
+	@git fetch origin
+	@if ! git merge-base --is-ancestor origin/master HEAD; then \
+		echo "You need to be up-to-date with master before you can continue!"; \
+		exit 1; \
+	fi
+
+UPTODATE_GIT_DEFINED = true
+
+endif
+
+
+# Run a 'terraform plan' step.
+#
+# Args:
+#   $1 - Path to the Terraform directory.
+#	$2 - true/false: is this a public-facing stack?
+#
+define terraform_plan
+	make uptodate-git
+	$(ROOT)/docker_run.py --aws -- \
+		--volume $(ROOT):$(ROOT) \
+		--workdir $(ROOT)/$(1) \
+		--env OP=plan \
+		--env GET_TFVARS=true \
+		--env BUCKET_NAME=$(TFVARS_BUCKET) \
+		--env OBJECT_KEY=$(TFVARS_KEY) \
+		--env IS_PUBLIC_FACING=$(2) \
+		$(TERRAFORM_WRAPPER_IMAGE)
+endef
+
+
+# Run a 'terraform apply' step.
+#
+# Args:
+#   $1 - Path to the Terraform directory.
+#
+define terraform_apply
+	make uptodate-git
+	$(ROOT)/docker_run.py --aws -- \
+		--volume $(ROOT):$(ROOT) \
+		--workdir $(ROOT)/$(1) \
+		--env BUCKET_NAME=$(TFPLAN_BUCKET) \
+		--env OP=apply \
+		$(TERRAFORM_WRAPPER_IMAGE)
+endef

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,6 +1,4 @@
 provider "aws" {
-  region = "${var.region}"
-
-  profile = "${var.profile}"
+  region  = "${var.region}"
   version = "1.46.0"
 }

--- a/terraform/public_service/main.tf
+++ b/terraform/public_service/main.tf
@@ -34,7 +34,7 @@ module "task" {
 }
 
 module "service" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/load_balanced?ref=v16.1.6"
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/service/prebuilt/rest/tcp?ref=v17.1.0"
 
   service_name       = "${var.name}"
   task_desired_count = "${var.task_desired_count}"
@@ -59,9 +59,6 @@ module "service" {
 
   task_definition_arn = "${module.task.task_definition_arn}"
 
-  healthcheck_path = "${var.healthcheck_path}"
-
-  target_group_protocol = "HTTP"
   listener_port         = "80"
   lb_arn                = "${var.lb_arn}"
 

--- a/terraform/public_service/outputs.tf
+++ b/terraform/public_service/outputs.tf
@@ -1,7 +1,3 @@
 output "target_group_arn" {
-  value = "${data.aws_alb_target_group.tg.arn}"
-}
-
-data "aws_alb_target_group" "tg" {
-  name = "${module.service.target_group_name}"
+  value = "${module.service.target_group_arn}"
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    bucket = "wellcomecollection-platform-infra"
-    key    = "terraform/archivematica-infra.tfstate"
+    bucket = "wellcomecollection-workflow-infra"
+    key    = "terraform/state/archivematica-infra.tfstate"
     region = "eu-west-1"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,10 +2,6 @@ variable "region" {
   default = "eu-west-1"
 }
 
-variable "profile" {
-  default = "wellcomedigitalplatform"
-}
-
 variable "name" {
   default = "archivematica"
 }


### PR DESCRIPTION
Related: https://github.com/wellcometrust/platform/pull/3157

In particular:

* Adding docs and a mechanism for creating temporary credentials with AssumeRole
* Creating the ACM certificate for archivematica.wellcomecollection.org so it's available
* Use newer terraform-modules so we don't get a stalemate with `data` modules
* Modify the RDS database names so they don't collide

I also added some stuff to the .gitignore to remove our plan files and tfvars files. I forced push the history to expunge them, but since this repo is public, we should assume everything in the tfvars file is compromised. Most of it is image IDs, which is fine, but the password for our "goobi" RDS instance was in there too. We should change that.