### PR TITLE
Set up task role permissions for storage service

### DIFF
--- a/terraform/nginx_service/main.tf
+++ b/terraform/nginx_service/main.tf
@@ -48,6 +48,7 @@ resource "aws_ecs_task_definition" "task" {
   family                = "${local.full_name}"
   container_definitions = "${module.container_definition.rendered}"
   execution_role_arn    = "${module.iam_roles.task_execution_role_arn}"
+  task_role_arn         = "${module.iam_roles.task_role_arn}"
 
   network_mode = "awsvpc"
 

--- a/terraform/nginx_service/outputs.tf
+++ b/terraform/nginx_service/outputs.tf
@@ -1,3 +1,7 @@
 output "service_name" {
   value = "${module.service.service_name}"
 }
+
+output "task_role_name" {
+  value = "${module.iam_roles.name}"
+}

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -139,6 +139,25 @@ resource "random_integer" "storage_service_django_key" {
   }
 }
 
+resource "aws_iam_role_policy" "storage_service_task_role_policy" {
+  role   = "${module.storage_service.task_role_name}"
+  policy = "${data.aws_iam_policy_document.storage_service_aws_permissions.json}"
+}
+
+
+data "aws_iam_policy_document" "storage_service_aws_permissions" {
+  statement {
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::wellcomecollection-storage-ingests/",
+    ]
+  }
+}
+
+
 module "storage_service" {
   source = "./nginx_service"
 


### PR DESCRIPTION
Give the Archivematica storage service permission to put objects into the storage-ingests bucket.

This will enable the Wellcome storage plugin to upload bags to S3 before notifying the Wellcome storage service about them.

Addresses https://github.com/wellcometrust/platform/issues/3486