### PR TITLE
Add Archivematica transfer source bucket

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -11,7 +11,38 @@ data "aws_iam_policy_document" "storage_service_aws_permissions" {
     ]
 
     resources = [
+      "${aws_s3_bucket.archivematica_drop.arn}",
       "${aws_s3_bucket.archivematica_drop.arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.archivematica_transfer.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:HeadBucket",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.archivematica_transfer.arn}/*",
     ]
   }
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -10,3 +10,8 @@ resource "aws_s3_bucket" "archivematica_drop" {
     enabled = true
   }
 }
+
+resource "aws_s3_bucket" "archivematica_transfer" {
+  bucket = "wellcomecollection-archivematica-transfer-source"
+  acl    = "private"
+}


### PR DESCRIPTION
Set up bucket for Archivematica transfer source, along with permissions required for browsing via the Archivematica storage service task.

* `HeadBucket` - check the bucket exists
* `ListBucket` - list bucket contents during browse
* `GetObject` - transfer file from bucket