### PR TITLE
Re-enable AIP indexing

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -38,7 +38,6 @@ module "mcp_worker_service" {
     ARCHIVEMATICA_MCPCLIENT_CLIENT_DATABASE                        = "MCP"
     ARCHIVEMATICA_MCPCLIENT_ELASTICSEARCHSERVER                    = "${local.elasticsearch_url}"
     ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_MCPARCHIVEMATICASERVER       = "${local.gearmand_hostname}:4730"
-    ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SEARCH_ENABLED               = "transfers"
     ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CAPTURE_CLIENT_SCRIPT_OUTPUT = true
     ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_SERVER                = "localhost:3310"
     ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CLAMAV_CLIENT_BACKEND        = "clamdscanner"
@@ -70,7 +69,6 @@ module "mcp_worker_service" {
 
     ARCHIVEMATICA_MCPSERVER_MCPARCHIVEMATICASERVER = "${local.gearmand_hostname}:4730"
 
-    ARCHIVEMATICA_MCPSERVER_SEARCH_ENABLED = "transfers"
   }
 
   mcp_server_env_vars_length = 7
@@ -185,7 +183,6 @@ module "dashboard_service" {
     ARCHIVEMATICA_DASHBOARD_CLIENT_HOST                    = "${module.rds_cluster.host}"
     ARCHIVEMATICA_DASHBOARD_CLIENT_PORT                    = "${module.rds_cluster.port}"
     ARCHIVEMATICA_DASHBOARD_CLIENT_DATABASE                = "MCP"
-    ARCHIVEMATICA_DASHBOARD_SEARCH_ENABLED                 = "transfers"
     ARCHIVEMATICA_DASHBOARD_DJANGO_ALLOWED_HOSTS           = "*"
     AM_GUNICORN_BIND                                       = "0.0.0.0:9000"
     WELLCOME_SS_URL                                        = "http://${local.storage_service_host}:${local.storage_service_port}"


### PR DESCRIPTION
AIP indexing was switched off because it was failing. Changes in core Archivematica mean that it works now - these environment variable changes switch it back on again. (The default value for this environment variable causes both AIPs and transfers to be indexed, rather than just transfers)

Fixes https://github.com/wellcometrust/platform/issues/3460