### PR TITLE
Allow access to the wellcomecollection-storage-access

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -31,12 +31,12 @@ data "aws_ssm_parameter" "archivematica_ss_api_key" {
 }
 
 locals {
-  rds_username       = "${data.aws_ssm_parameter.rds_username.value}"
-  rds_password       = "${data.aws_ssm_parameter.rds_password.value}"
-  elasticsearch_url  = "${data.aws_ssm_parameter.elasticsearch_url.value}"
-  admin_cidr_ingress = "${split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)}"
-  archivematica_username = "${data.aws_ssm_parameter.archivematica_username.value}"
-  archivematica_api_key = "${data.aws_ssm_parameter.archivematica_api_key.value}"
+  rds_username              = "${data.aws_ssm_parameter.rds_username.value}"
+  rds_password              = "${data.aws_ssm_parameter.rds_password.value}"
+  elasticsearch_url         = "${data.aws_ssm_parameter.elasticsearch_url.value}"
+  admin_cidr_ingress        = "${split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)}"
+  archivematica_username    = "${data.aws_ssm_parameter.archivematica_username.value}"
+  archivematica_api_key     = "${data.aws_ssm_parameter.archivematica_api_key.value}"
   archivematica_ss_username = "${data.aws_ssm_parameter.archivematica_ss_username.value}"
-  archivematica_ss_api_key = "${data.aws_ssm_parameter.archivematica_ss_api_key.value}"
+  archivematica_ss_api_key  = "${data.aws_ssm_parameter.archivematica_ss_api_key.value}"
 }

--- a/terraform/elasticache.tf
+++ b/terraform/elasticache.tf
@@ -12,6 +12,6 @@ resource "aws_elasticache_cluster" "archivematica" {
   engine_version       = "3.2.10"
   port                 = 6379
 
-  subnet_group_name    = "${aws_elasticache_subnet_group.archivematica.name}"
-  security_group_ids   = ["${local.interservice_security_group_id}"]
+  subnet_group_name  = "${aws_elasticache_subnet_group.archivematica.name}"
+  security_group_ids = ["${local.interservice_security_group_id}"]
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -3,7 +3,6 @@ resource "aws_iam_role_policy" "storage_service_task_role_policy" {
   policy = "${data.aws_iam_policy_document.storage_service_aws_permissions.json}"
 }
 
-
 data "aws_iam_policy_document" "storage_service_aws_permissions" {
   statement {
     actions = [
@@ -45,6 +44,18 @@ data "aws_iam_policy_document" "storage_service_aws_permissions" {
       "${aws_s3_bucket.archivematica_transfer.arn}/*",
     ]
   }
+
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::wellcomecollection-storage-access/*",
+      "arn:aws:s3:::wellcomecollection-storage-access",
+    ]
+  }
 }
 
 resource "aws_s3_bucket_policy" "archivematica_ingests_bucket_policy" {
@@ -66,7 +77,7 @@ data "aws_iam_policy_document" "archivematica_ingests_bucket_policy" {
       type = "AWS"
 
       identifiers = [
-        "${data.terraform_remote_state.storage_service.unpacker_task_role_arns}"
+        "${data.terraform_remote_state.storage_service.unpacker_task_role_arns}",
       ]
     }
   }

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -7,13 +7,14 @@ module "s3_start_transfer_lambda" {
   description     = "Start new Archivematica transfers for uploads to transfer bucket"
   name            = "s3_start_transfer"
   alarm_topic_arn = "${data.terraform_remote_state.shared_infra.lambda_error_alarm_arn}"
+
   environment_variables = {
-    "ARCHIVEMATICA_URL" = "https://${module.dashboard_service.hostname}"
-    "ARCHIVEMATICA_SS_URL" = "https://${module.storage_service.hostname}"
-    "ARCHIVEMATICA_USERNAME" = "${local.archivematica_username}"
-    "ARCHIVEMATICA_API_KEY" = "${local.archivematica_api_key}"
+    "ARCHIVEMATICA_URL"         = "https://${module.dashboard_service.hostname}"
+    "ARCHIVEMATICA_SS_URL"      = "https://${module.storage_service.hostname}"
+    "ARCHIVEMATICA_USERNAME"    = "${local.archivematica_username}"
+    "ARCHIVEMATICA_API_KEY"     = "${local.archivematica_api_key}"
     "ARCHIVEMATICA_SS_USERNAME" = "${local.archivematica_ss_username}"
-    "ARCHIVEMATICA_SS_API_KEY" = "${local.archivematica_ss_api_key}"
+    "ARCHIVEMATICA_SS_API_KEY"  = "${local.archivematica_ss_api_key}"
   }
 
   timeout = 120
@@ -28,7 +29,7 @@ resource "aws_lambda_permission" "allow_lambda" {
 }
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket    = "${aws_s3_bucket.archivematica_transfer.id}"
+  bucket = "${aws_s3_bucket.archivematica_transfer.id}"
 
   lambda_function {
     lambda_function_arn = "${module.s3_start_transfer_lambda.arn}"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,8 +1,8 @@
 locals {
   vpc_id = "${data.terraform_remote_state.workflow.vpc_id}"
 
-  network_private_subnets = "${data.terraform_remote_state.workflow.private_subnets}"
-  network_public_subnets  = "${data.terraform_remote_state.workflow.public_subnets}"
+  network_private_subnets     = "${data.terraform_remote_state.workflow.private_subnets}"
+  network_public_subnets      = "${data.terraform_remote_state.workflow.public_subnets}"
   network_num_private_subnets = "${data.terraform_remote_state.workflow.num_private_subnets}"
 
   interservice_security_group_id   = "${data.terraform_remote_state.workflow.interservice_security_group_id}"

--- a/terraform/modules/gearman_service/variables.tf
+++ b/terraform/modules/gearman_service/variables.tf
@@ -4,6 +4,7 @@ variable "env_vars" {
   type    = "map"
   default = {}
 }
+
 variable "env_vars_length" {
   default = 0
 }

--- a/terraform/modules/nginx_service/variables.tf
+++ b/terraform/modules/nginx_service/variables.tf
@@ -4,6 +4,7 @@ variable "env_vars" {
   type    = "map"
   default = {}
 }
+
 variable "env_vars_length" {
   default = 0
 }
@@ -30,7 +31,7 @@ variable "aws_region" {
 }
 
 variable "cpu" {
-  default = 640  # 768 - 128 for the sidecar
+  default = 640 # 768 - 128 for the sidecar
 }
 
 variable "memory" {

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -12,19 +12,21 @@ module "mcp_worker_service" {
   namespace_id = "${aws_service_discovery_private_dns_namespace.archivematica.id}"
 
   fits_container_image = "${module.fits_ngserver_repo_uri.value}"
-  fits_mount_points    = [
+
+  fits_mount_points = [
     {
       sourceVolume  = "pipeline-data"
       containerPath = "/var/archivematica/sharedDirectory"
-    }
+    },
   ]
 
   clamav_container_image = "artefactual/clamav:latest"
-  clamav_mount_points    = [
+
+  clamav_mount_points = [
     {
       sourceVolume  = "pipeline-data"
       containerPath = "/var/archivematica/sharedDirectory"
-    }
+    },
   ]
 
   mcp_client_env_vars = {
@@ -57,7 +59,7 @@ module "mcp_worker_service" {
     {
       sourceVolume  = "pipeline-data"
       containerPath = "/var/archivematica/sharedDirectory"
-    }
+    },
   ]
 
   mcp_server_env_vars = {
@@ -68,7 +70,6 @@ module "mcp_worker_service" {
     ARCHIVEMATICA_MCPSERVER_CLIENT_DATABASE = "MCP"
 
     ARCHIVEMATICA_MCPSERVER_MCPARCHIVEMATICASERVER = "${local.gearmand_hostname}:4730"
-
   }
 
   mcp_server_env_vars_length = 7
@@ -85,7 +86,7 @@ module "mcp_worker_service" {
     {
       sourceVolume  = "pipeline-data"
       containerPath = "/var/archivematica/sharedDirectory"
-    }
+    },
   ]
 }
 
@@ -126,7 +127,8 @@ module "storage_service" {
 
     # The volume mounts are owned by "root".  By default gunicorn runs with
     # the 'archivematica' user, which can't access these mounts.
-    SS_GUNICORN_USER  = "root"
+    SS_GUNICORN_USER = "root"
+
     SS_GUNICORN_GROUP = "root"
   }
 
@@ -142,15 +144,15 @@ module "storage_service" {
 
   mount_points = [
     {
-      sourceVolume  = "pipeline-data",
+      sourceVolume  = "pipeline-data"
       containerPath = "/var/archivematica/sharedDirectory"
     },
     {
-      sourceVolume  = "location-data",
+      sourceVolume  = "location-data"
       containerPath = "/home"
     },
     {
-      sourceVolume  = "staging-data",
+      sourceVolume  = "staging-data"
       containerPath = "/var/archivematica/storage_service"
     },
   ]
@@ -205,7 +207,7 @@ module "dashboard_service" {
 
   mount_points = [
     {
-      sourceVolume  = "pipeline-data",
+      sourceVolume  = "pipeline-data"
       containerPath = "/var/archivematica/sharedDirectory"
     },
   ]


### PR DESCRIPTION
In order to retrieve things from the Storage Service (AKA Betamax) we need to provide permissions from both the bucket policy and for the am-storage-service task role.

