### PR TITLE
Set nginx read timeout high for AIP download

### DIFF
--- a/dockerfiles/dashboard_nginx/etc/nginx/conf.d/archivematica.conf
+++ b/dockerfiles/dashboard_nginx/etc/nginx/conf.d/archivematica.conf
@@ -10,6 +10,10 @@ server {
   proxy_buffering off;
   proxy_next_upstream error;
 
+  # Prevent timeout on AIP download
+  # If this is set too low, attempting to download large AIPs will cause a 504 error
+  proxy_read_timeout 172800s;
+
   location ~ ".*" {
     proxy_pass http://localhost:9000;
   }

--- a/dockerfiles/storage_service_nginx/etc/nginx/conf.d/archivematica.conf
+++ b/dockerfiles/storage_service_nginx/etc/nginx/conf.d/archivematica.conf
@@ -10,6 +10,10 @@ server {
   proxy_buffering off;
   proxy_next_upstream error;
 
+  # Prevent timeout on AIP download
+  # If this is set too low, attempting to download large AIPs will cause a 504 error
+  proxy_read_timeout 172800s;
+
   location ~ ".*" {
     proxy_pass http://localhost:8000;
   }


### PR DESCRIPTION
Should prevent timeout during download of larger AIPs and partly address https://github.com/wellcometrust/platform/issues/3831