### PR TITLE
Fix archivematica deploy

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -77,7 +77,8 @@ data "aws_iam_policy_document" "archivematica_ingests_bucket_policy" {
       type = "AWS"
 
       identifiers = [
-        "${data.terraform_remote_state.storage_service.unpacker_task_role_arns}",
+        "${data.terraform_remote_state.storage_service_prod.unpacker_task_role_arn}",
+        "${data.terraform_remote_state.storage_service_staging.unpacker_task_role_arn}",
       ]
     }
   }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -52,8 +52,8 @@ data "aws_iam_policy_document" "storage_service_aws_permissions" {
     ]
 
     resources = [
-      "arn:aws:s3:::wellcomecollection-storage-access/*",
-      "arn:aws:s3:::wellcomecollection-storage-access",
+      "arn:aws:s3:::wellcomecollection-storage/*",
+      "arn:aws:s3:::wellcomecollection-storage",
     ]
   }
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -10,14 +10,26 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "storage_service" {
+data "terraform_remote_state" "storage_service_prod" {
   backend = "s3"
 
   config {
-    role_arn = "arn:aws:iam::975596993436:role/storage-developer"
+    role_arn = "arn:aws:iam::975596993436:role/storage-read_only"
 
     bucket = "wellcomecollection-storage-infra"
-    key    = "terraform/storage.tfstate"
+    key    = "terraform/storage-service/stack_prod.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "storage_service_staging" {
+  backend = "s3"
+
+  config {
+    role_arn = "arn:aws:iam::975596993436:role/storage-read_only"
+
+    bucket = "wellcomecollection-storage-infra"
+    key    = "terraform/storage-service/stack_staging.tfstate"
     region = "eu-west-1"
   }
 }


### PR DESCRIPTION
Fix the Archivematica deployment files in line with a few changes that happened recently.

1. Update references to storage service task role so that unpacker can be given access to the Archivematica ingests bucket.
2. Update bucket names so that Archivemaica has access to the warm/primary storage bucket.