### PR TITLE
Set a higher timeout on load balancer

### DIFF
--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -11,7 +11,11 @@ module "lb_dashboard" {
   service_lb_security_group_ids = [
     "${local.service_lb_security_group_id}",
   ]
-  idle_timeout = "3600"
+
+  # We set a high timeout here and on the dashboard load balancer to allow
+  # Archivematica time to prepare large AIP files for download
+  # If nginx is sending back 499 responses, this may not be high enough.
+  idle_timeout = 3600
 }
 
 module "lb_storage_service" {
@@ -31,5 +35,5 @@ module "lb_storage_service" {
   # We set a high timeout here and on the dashboard load balancer to allow
   # Archivematica time to prepare large AIP files for download
   # If nginx is sending back 499 responses, this may not be high enough.
-  idle_timeout = "3600"
+  idle_timeout = 3600
 }

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -11,6 +11,7 @@ module "lb_dashboard" {
   service_lb_security_group_ids = [
     "${local.service_lb_security_group_id}",
   ]
+  idle_timeout = "3600"
 }
 
 module "lb_storage_service" {
@@ -26,4 +27,9 @@ module "lb_storage_service" {
   service_lb_security_group_ids = [
     "${local.service_lb_security_group_id}",
   ]
+
+  # We set a high timeout here and on the dashboard load balancer to allow
+  # Archivematica time to prepare large AIP files for download
+  # If nginx is sending back 499 responses, this may not be high enough.
+  idle_timeout = "3600"
 }

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -4,6 +4,7 @@ resource "aws_alb" "load_balancer" {
 
   subnets         = ["${var.public_subnets}"]
   security_groups = ["${concat(var.service_lb_security_group_ids, list(aws_security_group.external_lb_security_group.id))}"]
+  idle_timeout    = "${var.idle_timeout}"
 }
 
 resource "aws_alb_listener" "https" {

--- a/terraform/modules/load_balancer/variables.tf
+++ b/terraform/modules/load_balancer/variables.tf
@@ -9,3 +9,5 @@ variable "name" {}
 variable "service_lb_security_group_ids" {
   type = "list"
 }
+
+variable "idle_timeout" {}


### PR DESCRIPTION
This allows time for downloads of larger AIPs to begin.

This is for https://github.com/wellcometrust/platform/issues/3831