### PR TITLE
Boost Archivematica database instance

### DIFF
--- a/terraform/modules/critical/rds.tf
+++ b/terraform/modules/critical/rds.tf
@@ -58,7 +58,7 @@ resource "aws_rds_cluster_instance" "archivematica" {
   # previous settings for context.
   #
   # See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html
-  instance_class = "db.t4g.medium"
+  instance_class = "db.r5.large"
 
   engine         = aws_rds_cluster.archivematica.engine
   engine_version = aws_rds_cluster.archivematica.engine_version

--- a/terraform/modules/critical/rds.tf
+++ b/terraform/modules/critical/rds.tf
@@ -39,26 +39,7 @@ resource "aws_rds_cluster_instance" "archivematica" {
   db_subnet_group_name = aws_db_subnet_group.archivematica.name
   publicly_accessible  = false
 
-  # Note: right-sizing this instance has been historically tricky.
-  # This is the history of our sizes, and the max connections, which has
-  # traditionally been our limiting factor:
-  #
-  #     db.r5.large       1000
-  #     db.t4g.large       135
-  #     db.t4g.medium       90
-  #
-  # In our earliest Archivematica deployments, we needed those 1000 connections
-  # even though they were mostly underused, because there was nothing in
-  # between.  More recently, we've noticed Archivematica using far fewer
-  # connections, and we've reduced this instance size.
-  #
-  # My guess is that newer versions of Archivematica are better at handling
-  # database connections -- it's doing the same work with fewer connections.
-  # The errors are pretty obvious if/when this goes wrong, but noting the
-  # previous settings for context.
-  #
-  # See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html
-  instance_class = "db.r5.large"
+  instance_class = "db.t4g.medium"
 
   engine         = aws_rds_cluster.archivematica.engine
   engine_version = aws_rds_cluster.archivematica.engine_version
@@ -115,6 +96,27 @@ module "aurora_rds_cluster" {
   aws_db_subnet_group_name = aws_db_subnet_group.archivematica.name
 
   snapshot_identifier = var.snapshot_identifier
+
+    # Note: right-sizing this instance has been historically tricky.
+  # This is the history of our sizes, and the max connections, which has
+  # traditionally been our limiting factor:
+  #
+  #     db.r5.large       1000
+  #     db.t4g.large       135
+  #     db.t4g.medium       90
+  #
+  # In our earliest Archivematica deployments, we needed those 1000 connections
+  # even though they were mostly underused, because there was nothing in
+  # between.  More recently, we've noticed Archivematica using far fewer
+  # connections, and we've reduced this instance size.
+  #
+  # My guess is that newer versions of Archivematica are better at handling
+  # database connections -- it's doing the same work with fewer connections.
+  # The errors are pretty obvious if/when this goes wrong, but noting the
+  # previous settings for context.
+  #
+  # See https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html
+  migration_instance_class = "db.r5.large"
 
   engine_version = "8.0.mysql_aurora.3.10.3"
 }

--- a/terraform/modules/critical/rds.tf
+++ b/terraform/modules/critical/rds.tf
@@ -97,7 +97,7 @@ module "aurora_rds_cluster" {
 
   snapshot_identifier = var.snapshot_identifier
 
-    # Note: right-sizing this instance has been historically tricky.
+  # Note: right-sizing this instance has been historically tricky.
   # This is the history of our sizes, and the max connections, which has
   # traditionally been our limiting factor:
   #


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. -->

Changes db size from db.t4g.medium to db.r5.large

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

