### PR TITLE
Remove bastion host from staging

### DIFF
--- a/terraform/modules/stack/cluster.tf
+++ b/terraform/modules/stack/cluster.tf
@@ -24,5 +24,4 @@ module "cluster" {
   instance_type = "c5.4xlarge"
 
   container_host_ami = var.container_host_ami
-  bastion_host_ami   = var.bastion_host_ami
 }

--- a/terraform/modules/stack/cluster/ec2.tf
+++ b/terraform/modules/stack/cluster/ec2.tf
@@ -4,8 +4,6 @@ module "container_host" {
   cluster_name = var.cluster_name
   vpc_id       = var.vpc_id
 
-  ssh_ingress_security_groups = module.bastion_host.ssh_controlled_ingress_sg
-
   subnets  = var.private_subnets
   key_name = "wellcomedigitalworkflow"
 
@@ -15,19 +13,4 @@ module "container_host" {
 
   ebs_volume_id      = var.ebs_volume_id
   container_host_ami = var.container_host_ami
-}
-
-module "bastion_host" {
-  source = "./bastion_host"
-
-  vpc_id = var.vpc_id
-
-  name = "${var.name}-bastion"
-
-  controlled_access_cidr_ingress = var.controlled_access_cidr_ingress
-
-  key_name         = var.key_name
-  subnet_list      = var.public_subnets
-  bastion_host_ami = var.bastion_host_ami
-
 }

--- a/terraform/modules/stack/cluster/variables.tf
+++ b/terraform/modules/stack/cluster/variables.tf
@@ -22,8 +22,3 @@ variable "container_host_ami" {
   description = "The AMI to use for the container host"
   type        = string
 }
-
-variable "bastion_host_ami" {
-  description = "The AMI to use for the bastion host"
-  type        = string
-}

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -79,8 +79,3 @@ variable "container_host_ami" {
   description = "The AMI to use for the container host"
   type        = string
 }
-
-variable "bastion_host_ami" {
-  description = "The AMI to use for the bastion host"
-  type        = string
-}

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -55,7 +55,7 @@ module "stack" {
   service_egress_security_group_id = data.terraform_remote_state.workflow.outputs.service_egress_security_group_id
   service_lb_security_group_id     = data.terraform_remote_state.workflow.outputs.service_lb_security_group_id
 
-  container_host_ami = data.aws_ami.container_host_ami.image_id
+  container_host_ami = "resolve:ssm:arn:aws:ssm:eu-west-1:299497370133:parameter/imagebuilder/weco-al2023-ecs-optimised-x86_64/latest"
 
   admin_cidr_ingress = local.admin_cidr_ingress
 

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -7,16 +7,6 @@ data "aws_ami" "container_host_ami" {
   }
 }
 
-data "aws_ami" "bastion_host_ami" {
-  most_recent = true
-  owners      = ["self"]
-  filter {
-    name   = "name"
-    values = ["weco-amzn2-hvm-x86_64*"]
-  }
-}
-
-
 module "stack" {
   source = "../modules/stack"
 
@@ -66,7 +56,6 @@ module "stack" {
   service_lb_security_group_id     = data.terraform_remote_state.workflow.outputs.service_lb_security_group_id
 
   container_host_ami = data.aws_ami.container_host_ami.image_id
-  bastion_host_ami   = data.aws_ami.bastion_host_ami.image_id
 
   admin_cidr_ingress = local.admin_cidr_ingress
 


### PR DESCRIPTION
## What does this change?

Removes the bastion host from the archivematica staging environment and update AMI to use Wellcome custom one.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Login to the container host is allowed using ```aws ssm start-session```
## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

