### PR TITLE
Add transfer event idempotency with DynamoDB

### DIFF
--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -14,7 +14,10 @@ A transfer package is a zip file containing the files, plus some metadata (inclu
 ```mermaid
 graph TD
     A[User uploads package<br/>to S3] -->|S3 PutObject notification| L{Lambda checks package<br/>has correct structure<br/>and metadata}
-    L -->|passes checks| S[trigger Archivematica transfer,<br/>upload 'success' log and<br/>tag S3 object]
+    L -->|passes checks| D{Claim S3 event<br/>in DynamoDB}
+    D -->|new event| S[trigger Archivematica transfer]
+    D -->|already claimed| X[stop without creating<br/>another transfer]
+    S --> C[store Transfer UUID,<br/>upload 'success' log and<br/>tag S3 object]
     L -->|fails checks| F[upload 'failed' log]
 
     classDef failedNode fill:#e01b2f,stroke:#e01b2f,fill-opacity:0.15
@@ -39,6 +42,34 @@ It records a success/fail result by uploading a small log file alongside the ori
 If it starts a transfer successfully, it tags the S3 object with the transfer ID.
 These tags will be used by the (yet-to-be-written) transfer monitor Lambda to check for Archivematica failures and/or clean up the bucket.
 
+## Idempotency
+
+S3 and Lambda can deliver the same notification more than once.  Before calling
+Archivematica, the Lambda conditionally writes the full S3 event identity to
+DynamoDB.  The identity includes the bucket, decoded object key, event type,
+sequencer, and version ID when present.  Only the invocation which creates the
+record can call Archivematica.
+
+The records have three states:
+
+* `SUBMITTING` means the event has been claimed and the Archivematica result is
+  not confirmed.
+* `SUBMITTED` means Archivematica returned a Transfer UUID.  These records keep
+  the UUID and receive a DynamoDB TTL approximately 90 days in the future.
+* `UNKNOWN` means the Archivematica request raised after the event was claimed,
+  so the outcome may be uncertain.
+
+`SUBMITTING` and `UNKNOWN` records do not expire or retry automatically.  They
+must be compared with the Archivematica dashboard and CloudWatch logs before an
+operator changes or removes the record.  DynamoDB errors fail the Lambda
+invocation and prevent an unclaimed request from reaching Archivematica.
+
+The Transfer UUID is committed to DynamoDB before S3 tags and the success log
+are written.  If either S3 operation fails afterwards, the Transfer will not be
+created again on redelivery; use the DynamoDB record to repair the feedback
+manually.  After DynamoDB eventually deletes a `SUBMITTED` record through TTL,
+replaying that old notification could create another Transfer.
+
 
 
 ## Deployment
@@ -50,7 +81,7 @@ This Lambda is automatically deployed with the latest version whenever you apply
 ## Running tests
 
 ```console
-$ coverage run -m py.test src/test_*.py
+$ coverage run -m pytest tests
 $ coverage report
 ```
 

--- a/lambdas/s3_start_transfer/src/idempotency.py
+++ b/lambdas/s3_start_transfer/src/idempotency.py
@@ -1,0 +1,137 @@
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import os
+import urllib.parse
+
+from botocore.exceptions import ClientError
+
+
+SUBMITTING = "SUBMITTING"
+SUBMITTED = "SUBMITTED"
+UNKNOWN = "UNKNOWN"
+SUBMITTED_RETENTION = dt.timedelta(days=90)
+
+
+@dataclasses.dataclass(frozen=True)
+class S3EventIdentity:
+    bucket: str
+    object_key: str
+    event_name: str
+    sequencer: str
+    version_id: str = None
+
+    @classmethod
+    def from_record(cls, record):
+        s3_object = record["s3"]["object"]
+
+        return cls(
+            bucket=record["s3"]["bucket"]["name"],
+            object_key=urllib.parse.unquote_plus(s3_object["key"], encoding="utf-8"),
+            event_name=record["eventName"],
+            sequencer=s3_object["sequencer"],
+            version_id=s3_object.get("versionId"),
+        )
+
+    @property
+    def event_id(self):
+        identity = {
+            "bucket": self.bucket,
+            "event_name": self.event_name,
+            "object_key": self.object_key,
+            "sequencer": self.sequencer,
+            "version_id": self.version_id,
+        }
+        encoded_identity = json.dumps(
+            identity, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+
+        return hashlib.sha256(encoded_identity).hexdigest()
+
+
+def _utc_now():
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _format_timestamp(timestamp):
+    return timestamp.isoformat().replace("+00:00", "Z")
+
+
+class EventLedger:
+    def __init__(self, table):
+        self._table = table
+
+    @classmethod
+    def from_session(cls, sess):
+        table_name = os.environ["IDEMPOTENCY_TABLE_NAME"]
+        table = sess.resource("dynamodb").Table(table_name)
+        return cls(table)
+
+    def claim(self, event, *, now=None):
+        now = now or _utc_now()
+        timestamp = _format_timestamp(now)
+        item = {
+            "event_id": event.event_id,
+            "bucket": event.bucket,
+            "object_key": event.object_key,
+            "event_name": event.event_name,
+            "sequencer": event.sequencer,
+            "state": SUBMITTING,
+            "created_at": timestamp,
+            "updated_at": timestamp,
+        }
+        if event.version_id is not None:
+            item["version_id"] = event.version_id
+
+        try:
+            self._table.put_item(
+                Item=item,
+                ConditionExpression="attribute_not_exists(event_id)",
+            )
+        except ClientError as err:
+            if err.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+
+        return True
+
+    def mark_submitted(self, event, transfer_uuid, *, now=None):
+        now = now or _utc_now()
+        submitted_at = _format_timestamp(now)
+        expires_at = int((now + SUBMITTED_RETENTION).timestamp())
+
+        self._table.update_item(
+            Key={"event_id": event.event_id},
+            UpdateExpression=(
+                "SET #state = :submitted, transfer_uuid = :transfer_uuid, "
+                "submitted_at = :submitted_at, updated_at = :updated_at, "
+                "expires_at = :expires_at"
+            ),
+            ConditionExpression="#state = :submitting",
+            ExpressionAttributeNames={"#state": "state"},
+            ExpressionAttributeValues={
+                ":submitting": SUBMITTING,
+                ":submitted": SUBMITTED,
+                ":transfer_uuid": transfer_uuid,
+                ":submitted_at": submitted_at,
+                ":updated_at": submitted_at,
+                ":expires_at": expires_at,
+            },
+        )
+
+    def mark_unknown(self, event, *, now=None):
+        now = now or _utc_now()
+        updated_at = _format_timestamp(now)
+
+        self._table.update_item(
+            Key={"event_id": event.event_id},
+            UpdateExpression="SET #state = :unknown, updated_at = :updated_at",
+            ConditionExpression="#state = :submitting",
+            ExpressionAttributeNames={"#state": "state"},
+            ExpressionAttributeValues={
+                ":submitting": SUBMITTING,
+                ":unknown": UNKNOWN,
+                ":updated_at": updated_at,
+            },
+        )

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -4,7 +4,6 @@ import io
 import os
 import os.path
 import traceback
-import urllib.parse
 import zipfile
 
 import boto3
@@ -12,6 +11,7 @@ import boto3
 import archivematica
 from archivematica import choose_processing_config
 from big_s3 import S3File
+from idempotency import EventLedger, S3EventIdentity
 from log_handler import Logger
 from verify_transfer_packages import (
     VerificationFailure,
@@ -105,7 +105,17 @@ def get_identifiers(*, s3, logger, bucket, key):
         }
 
 
-def run_transfer(sess, *, bucket, key):
+def _record_start_failure(sess, logger, *, bucket, key, err):
+    logger.write(f"Error starting transfer: {err}")
+    logger.write("Ask somebody to check the CloudWatch logs for more info")
+    _write_log(sess, logger, bucket=bucket, key=key, result="failed")
+
+    print(f"Error starting transfer for s3://{bucket}/{key}")
+
+
+def run_transfer(sess, *, event):
+    bucket = event.bucket
+    key = event.object_key
     logger = Logger()
 
     # Run some verifications on the object before we sent it to Archivematica.
@@ -141,7 +151,7 @@ def run_transfer(sess, *, bucket, key):
             print(f"Unable to decompress s3://{bucket}/{key}: {err}")
             return
 
-    # Now try to start a transfer in Archivematica.
+    # Finish the work which can safely be repeated before claiming the event.
     try:
         processing_config = choose_processing_config(key)
 
@@ -151,23 +161,46 @@ def run_transfer(sess, *, bucket, key):
         target_path = archivematica.get_target_path(
             bucket=bucket, directory=directory, key=key_path
         )
+    except Exception as err:
+        _record_start_failure(sess, logger, bucket=bucket, key=key, err=err)
+        return
 
-        target_name = os.path.basename(key)
+    # Claim immediately before the request which creates an Archivematica Transfer.
+    ledger = EventLedger.from_session(sess)
+    if not ledger.claim(event):
+        print(
+            f"Skipping previously claimed S3 event {event.event_id} "
+            f"for s3://{bucket}/{key}"
+        )
+        return
+
+    target_name = os.path.basename(key)
+    try:
         transfer_id = archivematica.start_transfer(
             name=target_name,
             path=target_path,
             processing_config=processing_config,
             accession_number=identifiers["accession_number"],
         )
+    except Exception as err:
+        ledger.mark_unknown(event)
+        print(f"Marked event {event.event_id} UNKNOWN for s3://{bucket}/{key}")
+        _record_start_failure(sess, logger, bucket=bucket, key=key, err=err)
+        return
 
-        tags = {
-            "Archivematica-TransferId": transfer_id,
-            "Archivematica-ProcessingConfig": processing_config,
-            "Archivematica-AccessionNumber": identifiers["accession_number"],
-            "Archivematica-CatalogueIdentifier": identifiers["dc.identifier"],
-            "Archivematica-TransferStartedAt": dt.datetime.now().isoformat(),
-        }
+    # The Transfer UUID is the confirmation boundary. Persist it before any
+    # best-effort S3 feedback so the event cannot create another Transfer.
+    ledger.mark_submitted(event, transfer_id)
 
+    tags = {
+        "Archivematica-TransferId": transfer_id,
+        "Archivematica-ProcessingConfig": processing_config,
+        "Archivematica-AccessionNumber": identifiers["accession_number"],
+        "Archivematica-CatalogueIdentifier": identifiers["dc.identifier"],
+        "Archivematica-TransferStartedAt": dt.datetime.now().isoformat(),
+    }
+
+    try:
         sess.client("s3").put_object_tagging(
             Bucket=bucket,
             Key=key,
@@ -180,40 +213,42 @@ def run_transfer(sess, *, bucket, key):
             },
         )
     except Exception as err:
-        logger.write(f"Error starting transfer: {err}")
-        logger.write("Ask somebody to check the CloudWatch logs for more info")
-        _write_log(sess, logger, bucket=bucket, key=key, result="failed")
+        _record_start_failure(sess, logger, bucket=bucket, key=key, err=err)
+        return
 
-        print(f"Error starting transfer for s3://{bucket}/{key}")
-    else:
-        logger.write("Started successful transfer!")
-        logger.write(f"Archivematica transfer ID is {transfer_id}")
-        _write_log(sess, logger, bucket=bucket, key=key, result="success", tags=tags)
+    logger.write("Started successful transfer!")
+    logger.write(f"Archivematica transfer ID is {transfer_id}")
+    _write_log(sess, logger, bucket=bucket, key=key, result="success", tags=tags)
 
-        print("Started transfer {}".format(transfer_id))
+    print("Started transfer {}".format(transfer_id))
 
 
 def main(event, context=None):
     sess = boto3.Session()
+    first_failure = None
 
     for record in event["Records"]:
-        # Get the object from the event and show its content type
-        bucket = record["s3"]["bucket"]["name"]
-        key = urllib.parse.unquote_plus(record["s3"]["object"]["key"], encoding="utf-8")
-
         try:
-            run_transfer(sess, bucket=bucket, key=key)
-        except Exception:
+            run_transfer(sess, event=S3EventIdentity.from_record(record))
+        except Exception as err:
             print(traceback.format_exc())
             print("Error thrown, skipping to next record...")
-            continue
+            if first_failure is None:
+                first_failure = err
+
+    if first_failure is not None:
+        raise first_failure
 
 
 if __name__ == "__main__":  # pragma: no cover
-    s3 = boto3.resource("s3")
+    sess = boto3.Session()
 
     run_transfer(
-        s3,
-        bucket="wellcomecollection-archivematica-transfer-source",
-        key="born-digital-accessions/WT_B_9_2_2.zip",
+        sess,
+        event=S3EventIdentity(
+            bucket="wellcomecollection-archivematica-transfer-source",
+            object_key="born-digital-accessions/WT_B_9_2_2.zip",
+            event_name="ObjectCreated:Put",
+            sequencer="manual",
+        ),
     )

--- a/lambdas/s3_start_transfer/tests/conftest.py
+++ b/lambdas/s3_start_transfer/tests/conftest.py
@@ -4,6 +4,8 @@ import pathlib
 import secrets
 import sys
 
+import boto3
+from moto import mock_dynamodb2
 import pytest
 
 sys.path.append(str(pathlib.Path(__file__).parent.parent / "src"))
@@ -12,3 +14,24 @@ sys.path.append(str(pathlib.Path(__file__).parent.parent / "src"))
 @pytest.fixture
 def bucket_name():
     return f"bucket-{secrets.token_hex(5)}"
+
+
+@pytest.fixture
+def idempotency_table(monkeypatch):
+    table_name = f"events-{secrets.token_hex(5)}"
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("IDEMPOTENCY_TABLE_NAME", table_name)
+
+    with mock_dynamodb2():
+        table = boto3.resource("dynamodb").create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "event_id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "event_id", "AttributeType": "S"}],
+            ProvisionedThroughput={
+                "ReadCapacityUnits": 5,
+                "WriteCapacityUnits": 5,
+            },
+        )
+        yield table

--- a/lambdas/s3_start_transfer/tests/test_archivematica.py
+++ b/lambdas/s3_start_transfer/tests/test_archivematica.py
@@ -36,6 +36,7 @@ def test_start_transfer(mock_am_post):
 @patch.object(archivematica, "am_api_post_json")
 def test_start_transfer_with_accession(mock_am_post):
     transfer_uuid = str(uuid.uuid4())
+    mock_am_post.return_value = {"id": transfer_uuid}
 
     actual_transfer_uuid = archivematica.start_transfer(
         name="test1.zip",

--- a/lambdas/s3_start_transfer/tests/test_idempotency.py
+++ b/lambdas/s3_start_transfer/tests/test_idempotency.py
@@ -1,0 +1,137 @@
+import concurrent.futures
+import datetime as dt
+import threading
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+import pytest
+
+from idempotency import (
+    EventLedger,
+    S3EventIdentity,
+    SUBMITTED,
+    SUBMITTING,
+    UNKNOWN,
+)
+
+
+def _event(*, sequencer="0001", version_id=None):
+    return S3EventIdentity(
+        bucket="transfer-bucket",
+        object_key="born-digital/package name.zip",
+        event_name="ObjectCreated:Put",
+        sequencer=sequencer,
+        version_id=version_id,
+    )
+
+
+def test_s3_event_identity_preserves_event_fields():
+    event = S3EventIdentity.from_record(
+        {
+            "eventName": "ObjectCreated:CompleteMultipartUpload",
+            "s3": {
+                "bucket": {"name": "transfer-bucket"},
+                "object": {
+                    "key": "born-digital%2Fpackage+name.zip",
+                    "sequencer": "00ABC123",
+                    "versionId": "version-1",
+                },
+            },
+        }
+    )
+
+    assert event == S3EventIdentity(
+        bucket="transfer-bucket",
+        object_key="born-digital/package name.zip",
+        event_name="ObjectCreated:CompleteMultipartUpload",
+        sequencer="00ABC123",
+        version_id="version-1",
+    )
+
+
+def test_sequencer_and_version_id_are_part_of_event_identity():
+    original = _event()
+
+    assert _event(sequencer="0002").event_id != original.event_id
+    assert _event(version_id="version-1").event_id != original.event_id
+    assert (
+        _event(version_id="version-2").event_id
+        != _event(version_id="version-1").event_id
+    )
+
+
+def test_sequential_claim_of_same_event_has_one_winner(idempotency_table):
+    ledger = EventLedger(idempotency_table)
+    event = _event()
+
+    assert ledger.claim(event)
+    assert not ledger.claim(event)
+
+    item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+    assert item["state"] == SUBMITTING
+    assert item["bucket"] == event.bucket
+    assert item["object_key"] == event.object_key
+    assert item["event_name"] == event.event_name
+    assert item["sequencer"] == event.sequencer
+    assert "expires_at" not in item
+
+
+def test_concurrent_claim_of_same_event_has_one_winner(idempotency_table):
+    ledger = EventLedger(idempotency_table)
+    event = _event()
+    barrier = threading.Barrier(2)
+
+    def claim():
+        barrier.wait()
+        return ledger.claim(event)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: claim(), range(2)))
+
+    assert sorted(results) == [False, True]
+    assert idempotency_table.scan()["Count"] == 1
+
+
+def test_claim_propagates_dynamodb_failure(idempotency_table):
+    ledger = EventLedger(idempotency_table)
+    dynamodb_error = ClientError(
+        {"Error": {"Code": "InternalServerError", "Message": "unavailable"}},
+        "PutItem",
+    )
+
+    with patch.object(
+        idempotency_table, "put_item", side_effect=dynamodb_error
+    ), pytest.raises(ClientError, match="InternalServerError"):
+        ledger.claim(_event())
+
+
+def test_submitting_event_is_marked_submitted_with_uuid_and_ttl(
+    idempotency_table,
+):
+    ledger = EventLedger(idempotency_table)
+    event = _event(version_id="version-1")
+    claimed_at = dt.datetime(2026, 7, 31, 8, 0, tzinfo=dt.timezone.utc)
+    submitted_at = claimed_at + dt.timedelta(minutes=1)
+
+    ledger.claim(event, now=claimed_at)
+    ledger.mark_submitted(event, "transfer-uuid", now=submitted_at)
+
+    item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+    assert item["state"] == SUBMITTED
+    assert item["transfer_uuid"] == "transfer-uuid"
+    assert item["version_id"] == "version-1"
+    assert item["submitted_at"] == "2026-07-31T08:01:00Z"
+    assert item["expires_at"] == int((submitted_at + dt.timedelta(days=90)).timestamp())
+
+
+def test_unknown_event_does_not_have_ttl(idempotency_table):
+    ledger = EventLedger(idempotency_table)
+    event = _event()
+
+    ledger.claim(event)
+    ledger.mark_unknown(event)
+
+    item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+    assert item["state"] == UNKNOWN
+    assert "transfer_uuid" not in item
+    assert "expires_at" not in item

--- a/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
@@ -1,19 +1,31 @@
 # -*- encoding: utf-8 -*-
 
+import io
 import re
+import zipfile
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import boto3
+from botocore.exceptions import ClientError
 from moto import mock_s3
 import pytest
 
 import archivematica
+from idempotency import (
+    EventLedger,
+    S3EventIdentity,
+    SUBMITTED,
+    SUBMITTING,
+    UNKNOWN,
+)
 import s3_start_transfer
 
 
 def _write_transfer_package(
-    s3, *, bucket_name, filename, key="born-digital/transfer_package.zip"
+    sess, *, bucket_name, filename, key="born-digital/transfer_package.zip"
 ):
+    s3 = sess.resource("s3")
     bucket = s3.Bucket(bucket_name)
     bucket.create()
 
@@ -22,7 +34,39 @@ def _write_transfer_package(
     return key
 
 
-def _find_log_object(s3, *, bucket_name):
+def _write_accession_package(
+    sess, *, bucket_name, key="born-digital-accessions/LEMON_1234.zip"
+):
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("record.txt", "test transfer")
+        zf.writestr(
+            "metadata/metadata.csv",
+            (
+                "filename,collection_reference,accession_number\n"
+                "objects/,LEMON,1234\n"
+            ),
+        )
+
+    bucket = sess.resource("s3").Bucket(bucket_name)
+    bucket.create()
+    bucket.put_object(Key=key, Body=archive.getvalue())
+
+    return key
+
+
+def _event(bucket, key, *, sequencer="0001", version_id=None):
+    return S3EventIdentity(
+        bucket=bucket,
+        object_key=key,
+        event_name="ObjectCreated:Put",
+        sequencer=sequencer,
+        version_id=version_id,
+    )
+
+
+def _find_log_object(sess, *, bucket_name):
+    s3 = sess.resource("s3")
     bucket = s3.Bucket(bucket_name)
 
     bucket_objects = list(bucket.objects.all())
@@ -35,6 +79,7 @@ def _find_log_object(s3, *, bucket_name):
     return bucket.Object(log_key)
 
 
+@pytest.mark.usefixtures("idempotency_table")
 class TestStartTransfer:
     @mock_s3
     @patch.object(archivematica, "start_transfer")
@@ -42,13 +87,14 @@ class TestStartTransfer:
     def test_valid_transfer_is_started(
         self, mock_get_target_path, mock_start_transfer, bucket_name
     ):
-        s3 = boto3.resource("s3")
+        mock_start_transfer.return_value = "transfer-uuid"
+        sess = boto3.Session()
 
         key = _write_transfer_package(
-            s3, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
         )
 
-        s3_start_transfer.run_transfer(s3, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
         mock_get_target_path.assert_called_with(
             bucket=bucket_name, directory="born-digital", key="transfer_package.zip"
@@ -66,16 +112,12 @@ class TestStartTransfer:
     def test_valid_accession_transfer_is_started(
         self, mock_get_target_path, mock_start_transfer, bucket_name
     ):
-        s3 = boto3.resource("s3")
+        mock_start_transfer.return_value = "transfer-uuid"
+        sess = boto3.Session()
 
-        key = _write_transfer_package(
-            s3,
-            bucket_name=bucket_name,
-            filename="valid_accession_package.zip",
-            key="born-digital-accessions/LEMON_1234.zip",
-        )
+        key = _write_accession_package(sess, bucket_name=bucket_name)
 
-        s3_start_transfer.run_transfer(s3, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
         mock_get_target_path.assert_called_with(
             bucket=bucket_name,
@@ -95,15 +137,16 @@ class TestStartTransfer:
     def test_valid_transfer_creates_success_log(
         self, mock_get_target_path, mock_start_transfer, bucket_name
     ):
-        s3 = boto3.resource("s3")
+        mock_start_transfer.return_value = "transfer-uuid"
+        sess = boto3.Session()
 
         key = _write_transfer_package(
-            s3, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
         )
 
-        s3_start_transfer.run_transfer(s3, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
-        log_object = _find_log_object(s3, bucket_name=bucket_name)
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
 
         # Example: born-digital/transfer_package.zip.success.2019-12-13_14-46-09.log
         assert re.match(
@@ -116,14 +159,14 @@ class TestStartTransfer:
 
     @mock_s3
     def test_verification_failure_writes_failed_log(self, bucket_name):
-        s3 = boto3.resource("s3")
+        sess = boto3.Session()
         key = _write_transfer_package(
-            s3, bucket_name=bucket_name, filename="no_metadata_csv.zip"
+            sess, bucket_name=bucket_name, filename="no_metadata_csv.zip"
         )
 
-        s3_start_transfer.run_transfer(s3, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
-        log_object = _find_log_object(s3, bucket_name=bucket_name)
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
 
         # Example: born-digital/transfer_package.zip.failed.2019-12-13_14-46-09.log
         assert re.match(
@@ -132,7 +175,7 @@ class TestStartTransfer:
         )
 
         log_text = log_object.get()["Body"].read()
-        assert b"== Check 3: verify_has_a_metadata_csv ==\nCheck failed:" in log_text
+        assert b"== Check 1: verify_has_a_metadata_csv ==\nCheck failed:" in log_text
 
     @mock_s3
     @patch.object(archivematica, "start_transfer")
@@ -142,37 +185,38 @@ class TestStartTransfer:
         [
             ("no_metadata_csv.zip", "born-digital/LEMON_1234.zip"),
             ("no_metadata_csv.zip", "born-digital-accessions/LEMON_1234.zip"),
-            ("valid_accession_package.zip", "born-digital/LEMON_1234.zip"),
             ("valid_transfer_package.zip", "born-digital-accessions/LEMON_1234.zip"),
         ],
     )
     def test_verification_failure_does_not_start_transfer(
         self, mock_get_target_path, mock_start_transfer, bucket_name, filename, key
     ):
-        s3 = boto3.resource("s3")
+        sess = boto3.Session()
         key = _write_transfer_package(
-            s3, bucket_name=bucket_name, filename=filename, key=key
+            sess, bucket_name=bucket_name, filename=filename, key=key
         )
 
-        s3_start_transfer.run_transfer(s3, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
         mock_get_target_path.assert_not_called()
         mock_start_transfer.assert_not_called()
 
     @mock_s3
-    def test_error_while_calling_archivematica_writes_failure_log(self, bucket_name):
-        s3 = boto3.resource("s3")
+    def test_storage_service_error_writes_failure_log(
+        self, bucket_name, idempotency_table
+    ):
+        sess = boto3.Session()
         key = _write_transfer_package(
-            s3, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
         )
 
         def boom(*args, **kwargs):
             raise ValueError("BOOM!")
 
         with patch.object(archivematica, "get_target_path", boom):
-            s3_start_transfer.run_transfer(s3, bucket=bucket_name, key=key)
+            s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
-        log_object = _find_log_object(s3, bucket_name=bucket_name)
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
 
         # Example: born-digital/transfer_package.zip.failed.2019-12-13_14-46-09.log
         assert re.match(
@@ -182,21 +226,245 @@ class TestStartTransfer:
 
         log_text = log_object.get()["Body"].read()
         assert b"Error starting transfer: BOOM!" in log_text
+        assert idempotency_table.scan()["Count"] == 0
+
+    @mock_s3
+    @patch.object(archivematica, "start_transfer", return_value="transfer-uuid")
+    @patch.object(archivematica, "get_target_path")
+    def test_sequential_delivery_starts_one_transfer(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+        idempotency_table,
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+
+        s3_start_transfer.run_transfer(sess, event=event)
+        s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_start_transfer.assert_called_once()
+        item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+        assert item["state"] == SUBMITTED
+        assert item["transfer_uuid"] == "transfer-uuid"
+
+    @mock_s3
+    @patch.object(
+        archivematica, "start_transfer", side_effect=["transfer-1", "transfer-2"]
+    )
+    @patch.object(archivematica, "get_target_path")
+    def test_new_sequencer_starts_a_new_transfer(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+        idempotency_table,
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+
+        s3_start_transfer.run_transfer(
+            sess, event=_event(bucket_name, key, sequencer="0001")
+        )
+        s3_start_transfer.run_transfer(
+            sess, event=_event(bucket_name, key, sequencer="0002")
+        )
+
+        assert mock_start_transfer.call_count == 2
+        items = idempotency_table.scan()["Items"]
+        assert len(items) == 2
+        assert {item["transfer_uuid"] for item in items} == {
+            "transfer-1",
+            "transfer-2",
+        }
+
+    @mock_s3
+    @patch.object(archivematica, "get_target_path")
+    def test_event_is_submitting_during_archivematica_call(
+        self, mock_get_target_path, bucket_name, idempotency_table
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+
+        def start_transfer(**kwargs):
+            item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+            assert item["state"] == SUBMITTING
+            assert "transfer_uuid" not in item
+            return "transfer-uuid"
+
+        with patch.object(archivematica, "start_transfer", start_transfer):
+            s3_start_transfer.run_transfer(sess, event=event)
+
+        item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+        assert item["state"] == SUBMITTED
+        assert item["transfer_uuid"] == "transfer-uuid"
+
+    @mock_s3
+    @patch.object(archivematica, "start_transfer", return_value="transfer-uuid")
+    @patch.object(archivematica, "get_target_path")
+    def test_s3_feedback_failure_does_not_retry_submitted_transfer(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+        idempotency_table,
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+        s3_client = sess.client("s3")
+        resource = sess.resource
+        dynamodb = SimpleNamespace(Table=lambda _: idempotency_table)
+        tagging_error = ClientError(
+            {"Error": {"Code": "InternalError", "Message": "unavailable"}},
+            "PutObjectTagging",
+        )
+
+        with patch.object(
+            sess,
+            "resource",
+            side_effect=lambda service: (
+                dynamodb if service == "dynamodb" else resource(service)
+            ),
+        ), patch.object(sess, "client", return_value=s3_client), patch.object(
+            s3_client, "put_object_tagging", side_effect=tagging_error
+        ) as mock_put_object_tagging:
+            s3_start_transfer.run_transfer(sess, event=event)
+            s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_start_transfer.assert_called_once()
+        mock_put_object_tagging.assert_called_once()
+        item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+        assert item["state"] == SUBMITTED
+        assert item["transfer_uuid"] == "transfer-uuid"
+
+    @mock_s3
+    @patch.object(archivematica, "get_target_path")
+    def test_unknown_submission_is_not_retried(
+        self, mock_get_target_path, bucket_name, idempotency_table
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+
+        with patch.object(
+            archivematica, "start_transfer", side_effect=ValueError("BOOM!")
+        ) as mock_start_transfer:
+            s3_start_transfer.run_transfer(sess, event=event)
+            s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_start_transfer.assert_called_once()
+        item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+        assert item["state"] == UNKNOWN
+        assert "expires_at" not in item
+
+    @mock_s3
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
+    def test_stale_submitting_event_is_not_retried(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+        idempotency_table,
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+        EventLedger(idempotency_table).claim(event)
+
+        s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_start_transfer.assert_not_called()
+        item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+        assert item["state"] == SUBMITTING
+        assert "expires_at" not in item
+
+    @mock_s3
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
+    def test_dynamodb_claim_failure_prevents_archivematica_call(
+        self, mock_get_target_path, mock_start_transfer, bucket_name
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        dynamodb_error = ClientError(
+            {"Error": {"Code": "InternalServerError", "Message": "unavailable"}},
+            "PutItem",
+        )
+
+        with patch.object(EventLedger, "claim", side_effect=dynamodb_error):
+            with pytest.raises(ClientError, match="InternalServerError"):
+                s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
+
+        mock_start_transfer.assert_not_called()
+
+    @mock_s3
+    @patch.object(archivematica, "start_transfer", return_value="transfer-uuid")
+    @patch.object(archivematica, "get_target_path")
+    def test_dynamodb_confirmation_failure_leaves_submitting_without_feedback(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+        idempotency_table,
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+        dynamodb_error = ClientError(
+            {"Error": {"Code": "InternalServerError", "Message": "unavailable"}},
+            "UpdateItem",
+        )
+
+        with patch.object(EventLedger, "mark_submitted", side_effect=dynamodb_error):
+            with pytest.raises(ClientError, match="InternalServerError"):
+                s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_start_transfer.assert_called_once()
+        item = idempotency_table.get_item(Key={"event_id": event.event_id})["Item"]
+        assert item["state"] == SUBMITTING
+        assert "expires_at" not in item
+        assert (
+            sess.client("s3").get_object_tagging(Bucket=bucket_name, Key=key)["TagSet"]
+            == []
+        )
+        assert len(list(sess.resource("s3").Bucket(bucket_name).objects.all())) == 1
 
 
 @mock_s3
+@pytest.mark.usefixtures("idempotency_table")
 def test_main_runs_all_events(bucket_name):
-    s3 = boto3.resource("s3")
+    sess = boto3.Session()
 
     _write_transfer_package(
-        s3,
+        sess,
         bucket_name=bucket_name,
         filename="valid_transfer_package.zip",
         key="born-digital/transfer_package1.zip",
     )
 
     _write_transfer_package(
-        s3,
+        sess,
         bucket_name=bucket_name,
         filename="valid_transfer_package.zip",
         key="born-digital/transfer_package2.zip",
@@ -205,25 +473,76 @@ def test_main_runs_all_events(bucket_name):
     event = {
         "Records": [
             {
+                "eventName": "ObjectCreated:Put",
                 "s3": {
                     "bucket": {"name": bucket_name},
-                    "object": {"key": "born-digital%2Ftransfer_package1.zip"},
-                }
+                    "object": {
+                        "key": "born-digital%2Ftransfer_package1.zip",
+                        "sequencer": "0001",
+                    },
+                },
             },
             {
+                "eventName": "ObjectCreated:CompleteMultipartUpload",
                 "s3": {
                     "bucket": {"name": bucket_name},
-                    "object": {"key": "born-digital%2Ftransfer_package2.zip"},
-                }
+                    "object": {
+                        "key": "born-digital%2Ftransfer_package2.zip",
+                        "sequencer": "0002",
+                    },
+                },
             },
         ]
     }
 
     with patch.object(archivematica, "get_target_path"):
         with patch.object(archivematica, "start_transfer") as mock_start_transfer:
+            mock_start_transfer.side_effect = ["transfer-1", "transfer-2"]
             s3_start_transfer.main(event=event)
 
             assert mock_start_transfer.call_count == 2
+
+
+@pytest.mark.usefixtures("idempotency_table")
+def test_main_reports_infrastructure_failure_after_processing_all_records():
+    dynamodb_error = ClientError(
+        {"Error": {"Code": "InternalServerError", "Message": "unavailable"}},
+        "PutItem",
+    )
+    event = {
+        "Records": [
+            {
+                "eventName": "ObjectCreated:Put",
+                "s3": {
+                    "bucket": {"name": "transfer-bucket"},
+                    "object": {
+                        "key": "born-digital%2Fpackage1.zip",
+                        "sequencer": "0001",
+                    },
+                },
+            },
+            {
+                "eventName": "ObjectCreated:Put",
+                "s3": {
+                    "bucket": {"name": "transfer-bucket"},
+                    "object": {
+                        "key": "born-digital%2Fpackage2.zip",
+                        "sequencer": "0002",
+                    },
+                },
+            },
+        ]
+    }
+
+    with patch.object(
+        s3_start_transfer,
+        "run_transfer",
+        side_effect=[dynamodb_error, None],
+    ) as mock_run_transfer:
+        with pytest.raises(ClientError, match="InternalServerError"):
+            s3_start_transfer.main(event=event)
+
+    assert mock_run_transfer.call_count == 2
 
 
 @pytest.mark.parametrize("s3_key", ["digitised/b12345678.zip"])

--- a/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
@@ -12,7 +12,7 @@ from verify_transfer_packages import (
     verify_all_files_not_under_single_dir,
     verify_all_files_not_under_objects_dir,
     verify_has_a_metadata_csv,
-    verify_only_metadata_csv_in_metadata_dir,
+    verify_only_metadata_and_rights_csv_in_metadata_dir,
     verify_metadata_csv_has_dc_identifier,
     verify_metadata_csv_has_accession_fields,
     VerificationFailure,
@@ -35,7 +35,7 @@ class TestVerifyPackage:
         verify_all_files_not_under_single_dir,
         verify_all_files_not_under_objects_dir,
         verify_has_a_metadata_csv,
-        verify_only_metadata_csv_in_metadata_dir,
+        verify_only_metadata_and_rights_csv_in_metadata_dir,
         verify_metadata_csv_has_dc_identifier,
     ]
 
@@ -113,7 +113,7 @@ class TestVerifyHasMetadataCsv:
 
         assert str(err.value).startswith(
             "Your transfer package must have a file ``metadata/metadata.csv``\n"
-            "that describes the objects in the bag."
+            "that describes the objects in the package."
         )
 
     @pytest.mark.parametrize(
@@ -124,13 +124,15 @@ class TestVerifyHasMetadataCsv:
         verify_has_a_metadata_csv(file_listing=file_listing)
 
 
-class TestVerifyOnlyMetadataCsvInMetadataDir:
+class TestVerifyOnlyMetadataAndRightsCsvInMetadataDir:
     @pytest.mark.parametrize("name", ["extra_files_in_metadata_dir.zip"])
     def test_extra_files_in_metadata_dir_is_exception(self, name):
         file_listing = _get_file_listing(name)
 
         with pytest.raises(VerificationFailure) as err:
-            verify_only_metadata_csv_in_metadata_dir(file_listing=file_listing)
+            verify_only_metadata_and_rights_csv_in_metadata_dir(
+                file_listing=file_listing
+            )
 
         assert str(err.value).startswith(
             "Your transfer package has unexpected files in the ``metadata/`` folder.\n"
@@ -142,7 +144,7 @@ class TestVerifyOnlyMetadataCsvInMetadataDir:
     )
     def test_valid_transfer_package_is_okay(self, name):
         file_listing = _get_file_listing(name)
-        verify_only_metadata_csv_in_metadata_dir(file_listing=file_listing)
+        verify_only_metadata_and_rights_csv_in_metadata_dir(file_listing=file_listing)
 
 
 class TestVerifyMetadataCsvHasDcIdentifier:

--- a/terraform/modules/stack/lambda_s3_start_transfer.tf
+++ b/terraform/modules/stack/lambda_s3_start_transfer.tf
@@ -1,3 +1,19 @@
+resource "aws_dynamodb_table" "s3_start_transfer_events" {
+  name         = "archivematica-s3-start-transfer-events-${var.namespace}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "event_id"
+
+  attribute {
+    name = "event_id"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+}
+
 module "s3_start_transfer_lambda" {
   source     = "./lambda"
   handler    = "s3_start_transfer.main"
@@ -14,6 +30,7 @@ module "s3_start_transfer_lambda" {
     "ARCHIVEMATICA_API_KEY"     = var.archivematica_api_key
     "ARCHIVEMATICA_SS_USERNAME" = var.archivematica_ss_username
     "ARCHIVEMATICA_SS_API_KEY"  = var.archivematica_ss_api_key
+    "IDEMPOTENCY_TABLE_NAME"    = aws_dynamodb_table.s3_start_transfer_events.name
   }
 
   timeout = 120
@@ -56,4 +73,22 @@ data "aws_iam_policy_document" "allow_writing_log_files" {
 resource "aws_iam_role_policy" "allow_writing_log_files" {
   role   = module.s3_start_transfer_lambda.role_name
   policy = data.aws_iam_policy_document.allow_writing_log_files.json
+}
+
+data "aws_iam_policy_document" "allow_s3_start_transfer_idempotency" {
+  statement {
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+    ]
+
+    resources = [
+      aws_dynamodb_table.s3_start_transfer_events.arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "allow_s3_start_transfer_idempotency" {
+  role   = module.s3_start_transfer_lambda.role_name
+  policy = data.aws_iam_policy_document.allow_s3_start_transfer_idempotency.json
 }


### PR DESCRIPTION
## What does this change?

Adds DynamoDB-backed idempotency to `s3_start_transfer`. Each S3 event is claimed before calling Archivematica. Duplicate or concurrent deliveries are skipped, while genuine re-uploads remain valid because their sequencer or version ID differs.

Confirmed transfers store their UUID and expire after approximately 90 days. Uncertain submissions remain visible as SUBMITTING or UNKNOWN for manual investigation.

## How to test

Run:

```
cd lambdas/s3_start_transfer
coverage run -m pytest tests
```

Also run:

```
terraform -chdir=terraform/stack_staging validate
```

## How can we measure success?

- Each S3 event creates at most one Archivematica transfer.
- Duplicate deliveries are logged as skipped.
- Confirmed transfer UUIDs are stored in DynamoDB.
- `SUBMITTING` and `UNKNOWN` records remain rare and investigated.

## Have we considered potential risks?

- DynamoDB failures block submission by design: without a confirmed claim, calling Archivematica could create a duplicate. The existing Lambda alarm will report these failures.
- `SUBMITTING` and `UNKNOWN` records require manual investigation because Archivematica may have accepted the request before the Lambda failed. Retrying automatically could create another transfer.
- `SUBMITTED` records expire after approximately 90 days. Once deleted, replaying the original event could create another transfer.
- Once a transfer is `SUBMITTED`, redeliveries are skipped, so failed S3 tags or logs require manual repair. If Archivematica adds native idempotency keys, we should revisit this guard because safe end-to-end retries could become possible.

Fixes #182.