### PR TITLE
Prevent indefinite async storage polling

### DIFF
--- a/archivematica-apps/archivematica/overlay/src/archivematica/archivematicaCommon/storageService.wellcome.py
+++ b/archivematica-apps/archivematica/overlay/src/archivematica/archivematicaCommon/storageService.wellcome.py
@@ -37,6 +37,7 @@ LOGGER = logging.getLogger("archivematica.common")
 ASYNC_OBSERVATION_DEADLINE_SECONDS = 24 * 60 * 60
 ASYNC_POLL_TIMEOUT_SECONDS = 600
 ASYNC_MAX_POLL_INTERVAL_SECONDS = ASYNC_POLL_TIMEOUT_SECONDS / 2
+INTERRUPTED_ASYNC_ERROR_CODE = "async_operation_interrupted"
 
 
 class Error(requests.exceptions.RequestException):
@@ -417,6 +418,7 @@ def wait_for_async(response, *, operation):
                 was_error = payload["was_error"]
                 if was_error:
                     remote_error = payload["error"]
+                    remote_error_code = payload.get("error_code")
                 else:
                     result = payload["result"]
         except (
@@ -449,6 +451,19 @@ def wait_for_async(response, *, operation):
             continue
 
         if was_error:
+            if remote_error_code == INTERRUPTED_ASYNC_ERROR_CODE:
+                err = AsyncOutcomeUnknown(
+                    operation=operation,
+                    async_id=async_id,
+                    poll_url=poll_url,
+                    elapsed_seconds=elapsed_seconds(),
+                    reason=(
+                        "Storage Service reported an interrupted operation: "
+                        f"{remote_error}"
+                    ),
+                )
+                LOGGER.error("%s", err)
+                raise err
             errmsg = (
                 f"Storage Service async operation {async_id} for {operation} "
                 f"reported failure: {remote_error}"

--- a/archivematica-apps/archivematica/overlay/src/archivematica/archivematicaCommon/storageService.wellcome.py
+++ b/archivematica-apps/archivematica/overlay/src/archivematica/archivematicaCommon/storageService.wellcome.py
@@ -1,18 +1,22 @@
-"""
-Restore using await_for_async in storageService.py
+"""Wellcome's compatibility client for legacy asynchronous storage operations.
 
-This reverts d565dbf.  It can take a long time for the Archivematica storage
-service to successfully store an AIP in the Wellcome storage, because:
+This overlay reverts Archivematica commit d565dbf and restores the asynchronous
+Storage Service client removed in Artefactual issue #780. Storing a package can
+take a long time while its bag is repacked and Wellcome storage scales up.
 
-1. We unpack and repack the bag with the new External-Identifier
-2. The Wellcome storage service has to scale up to store a new bag,
-   which means it can take a long time to store a bag.
+Polling is bounded to prevent an accepted operation from occupying an
+Archivematica worker indefinitely, as seen in Wellcome issue #176:
+https://github.com/wellcomecollection/archivematica-infrastructure/issues/176
 
-Long term it would be nice to not diverge from the Archivematica codebase here,
-but unless we can speed up the storage service this is unlikely.
+The deadline only bounds how long Archivematica observes the operation. It does
+not cancel Storage Service work or prove that its side effects failed. A lost
+polling resource or expired deadline therefore has an unknown outcome. The
+exception and logs retain the Storage Service Async ID so an operator can
+reconcile the result before retrying or cleaning up.
 
-That commit refers to Artefactual issue #780, we should watch that also.
-
+This remains a containment measure. A durable design would persist accepted
+work outside the Storage Service web process, make submission idempotent, save
+the job ID as workflow state, and resume observation without holding a worker.
 """
 
 import logging
@@ -30,6 +34,10 @@ from archivematica.archivematicaCommon.common_metrics import ss_api_timer
 
 LOGGER = logging.getLogger("archivematica.common")
 
+ASYNC_OBSERVATION_DEADLINE_SECONDS = 24 * 60 * 60
+ASYNC_POLL_TIMEOUT_SECONDS = 600
+ASYNC_MAX_POLL_INTERVAL_SECONDS = ASYNC_POLL_TIMEOUT_SECONDS / 2
+
 
 class Error(requests.exceptions.RequestException):
     pass
@@ -41,6 +49,54 @@ class ResourceNotFound(Error):
 
 class WaitForAsyncError(Error):
     pass
+
+
+class AsyncOutcomeUnknown(WaitForAsyncError):
+    """The result of an accepted Storage Service operation is not known."""
+
+    def __init__(
+        self,
+        *,
+        operation,
+        async_id,
+        poll_url,
+        elapsed_seconds,
+        reason,
+    ):
+        self.operation = operation
+        self.async_id = async_id
+        self.poll_url = poll_url
+        self.elapsed_seconds = elapsed_seconds
+        self.reason = reason
+        super().__init__(
+            "Storage Service async operation "
+            f"{async_id} for {operation} has an unknown outcome after "
+            f"{elapsed_seconds:.1f} seconds: {reason}. Status URL: {poll_url}. "
+            "Do not submit it again until the Storage Service result and "
+            "storage side effects have been reconciled."
+        )
+
+
+class AsyncObservationDeadlineExceeded(AsyncOutcomeUnknown):
+    """Archivematica stopped observing an accepted operation at its deadline."""
+
+    def __init__(
+        self,
+        *,
+        operation,
+        async_id,
+        poll_url,
+        elapsed_seconds,
+        deadline_seconds,
+    ):
+        self.deadline_seconds = deadline_seconds
+        super().__init__(
+            operation=operation,
+            async_id=async_id,
+            poll_url=poll_url,
+            elapsed_seconds=elapsed_seconds,
+            reason=(f"the {deadline_seconds:g}-second observation deadline expired"),
+        )
 
 
 # ####################### INTERFACE WITH STORAGE API #########################
@@ -291,56 +347,115 @@ def browse_location(uuid, path):
     return browse
 
 
-def wait_for_async(response):
-    """
-    Poll for results on an async endpoint.
-    `response` should have a HTTP 202 (Accepted) status code, and is expected to
-    contain a Location header telling us where to get our results from.
-    `poll_seconds` controls how long we wait between poll requests.
-    `poll_timeout_seconds` controls how long we wait for a poll request to
-    complete before giving up and throwing an exception.
-    This function may raise exceptions. The caller can expect them to be
-    instances of ``requests.exceptions.RequestException``.
-    """
-    poll_timeout_seconds = 600
+def wait_for_async(response, *, operation):
+    """Poll an accepted Storage Service operation within an overall deadline.
 
+    ``response`` must be the HTTP response that accepted the operation and
+    supplied its status URL in the ``Location`` header. The deadline bounds
+    observation only: it does not cancel the remote work or establish whether
+    storage side effects happened.
+
+    Once Storage Service has accepted the operation, a missing status resource,
+    failed poll, or expired deadline has an unknown outcome. The raised
+    ``AsyncOutcomeUnknown`` retains the Async ID and warns callers not to submit
+    duplicate work before reconciling Storage Service and storage state.
+
+    All raised client errors remain instances of
+    ``requests.exceptions.RequestException`` for caller compatibility.
+    """
     response.raise_for_status()
 
-    # This is a hacky bit of code to get a proper URL here, because
-    # the Location header returns a relative URL, e.g. /api/v2/async/158
-    #
-    # There's a better way of constructing this but it works and there are
-    # other issues I want to fix.
-    poll_url = (
-        _storage_service_url().replace("/api/v2", "/") + response.headers["Location"]
-    ).replace("///", "/")
+    location = response.headers["Location"]
+    async_id = location.rstrip("/").rsplit("/", 1)[-1]
 
-    # We'll enter this loop while waiting for the Wellcome storage to store
-    # a package.  This isn't a fast process, so treat it as an exponential backoff.
-    # The first time, we'll wait 2 seconds, then 4, and so on up to 300 seconds.
+    # Storage Service returns a relative URL, e.g. /api/v2/async/158/. Keep the
+    # established base-URL behavior while retaining the original Location value
+    # for correlation.
+    poll_url = (_storage_service_url().replace("/api/v2", "/") + location).replace(
+        "///", "/"
+    )
+
+    started_at = time.monotonic()
+    deadline_at = started_at + ASYNC_OBSERVATION_DEADLINE_SECONDS
     poll_seconds = 2
 
-    while True:
-        LOGGER.info(
-            "Polling for response at %s; if not completed will wait %d seconds",
-            poll_url,
-            poll_seconds,
+    def elapsed_seconds():
+        return max(0, time.monotonic() - started_at)
+
+    def raise_deadline_exceeded():
+        err = AsyncObservationDeadlineExceeded(
+            operation=operation,
+            async_id=async_id,
+            poll_url=poll_url,
+            elapsed_seconds=elapsed_seconds(),
+            deadline_seconds=ASYNC_OBSERVATION_DEADLINE_SECONDS,
         )
-        poll_response = _storage_api_session(timeout=poll_timeout_seconds).get(poll_url)
-        poll_response.raise_for_status()
-        payload = poll_response.json()
-        if not payload["completed"]:
-            time.sleep(poll_seconds)
+        LOGGER.error("%s", err)
+        raise err
 
-            # Double the poll timeout.  Clamp it at a max wait of 300 seconds.
-            poll_seconds = min(poll_seconds * 2, poll_timeout_seconds / 2)
+    while True:
+        remaining_seconds = deadline_at - time.monotonic()
+        if remaining_seconds <= 0:
+            raise_deadline_exceeded()
 
+        LOGGER.info(
+            "Polling Storage Service async operation %s for %s at %s; "
+            "%.1f seconds remain",
+            async_id,
+            operation,
+            poll_url,
+            remaining_seconds,
+        )
+        try:
+            poll_response = _storage_api_session(
+                timeout=min(ASYNC_POLL_TIMEOUT_SECONDS, remaining_seconds)
+            ).get(poll_url)
+            poll_response.raise_for_status()
+            payload = poll_response.json()
+            completed = payload["completed"]
+            if completed:
+                was_error = payload["was_error"]
+                if was_error:
+                    remote_error = payload["error"]
+                else:
+                    result = payload["result"]
+        except (
+            requests.exceptions.RequestException,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+            if status_code == 404:
+                reason = "the Storage Service status resource returned HTTP 404"
+            else:
+                reason = f"the Storage Service status request failed: {exc}"
+            err = AsyncOutcomeUnknown(
+                operation=operation,
+                async_id=async_id,
+                poll_url=poll_url,
+                elapsed_seconds=elapsed_seconds(),
+                reason=reason,
+            )
+            LOGGER.error("%s", err)
+            raise err from exc
+
+        if not completed:
+            remaining_seconds = deadline_at - time.monotonic()
+            if remaining_seconds <= 0:
+                raise_deadline_exceeded()
+            time.sleep(min(poll_seconds, remaining_seconds))
+            poll_seconds = min(poll_seconds * 2, ASYNC_MAX_POLL_INTERVAL_SECONDS)
             continue
-        if payload["was_error"]:
-            errmsg = "Failure storing file: {}".format(payload["error"])
+
+        if was_error:
+            errmsg = (
+                f"Storage Service async operation {async_id} for {operation} "
+                f"reported failure: {remote_error}"
+            )
             LOGGER.warning(errmsg)
             raise WaitForAsyncError(errmsg)
-        return payload["result"]
+        return result
 
 
 def copy_files(source_location, destination_location, files):
@@ -380,7 +495,13 @@ def copy_files(source_location, destination_location, files):
     try:
         with ss_api_timer(function="copy_files"):
             response = _storage_api_session().post(url, json=move_files)
-        return (wait_for_async(response), None)
+        return (
+            wait_for_async(
+                response,
+                operation="copy_files",
+            ),
+            None,
+        )
     except requests.exceptions.RequestException as e:
         LOGGER.warning("Unable to move files with %s because %s", move_files, e)
         return (None, e)
@@ -460,7 +581,10 @@ def create_file(
             url = _storage_service_url() + "file/async/"
             with ss_api_timer(function="create_file"):
                 response = session.post(url, json=new_file, allow_redirects=False)
-            ret = wait_for_async(response)
+            ret = wait_for_async(
+                response,
+                operation="create_file",
+            )
         except requests.exceptions.RequestException as err:
             LOGGER.warning(errmsg, new_file, err)
             raise

--- a/archivematica-apps/archivematica/overlay/src/archivematica/archivematicaCommon/storageService.wellcome.py
+++ b/archivematica-apps/archivematica/overlay/src/archivematica/archivematicaCommon/storageService.wellcome.py
@@ -357,9 +357,10 @@ def wait_for_async(response, *, operation):
     storage side effects happened.
 
     Once Storage Service has accepted the operation, a missing status resource,
-    failed poll, or expired deadline has an unknown outcome. The raised
-    ``AsyncOutcomeUnknown`` retains the Async ID and warns callers not to submit
-    duplicate work before reconciling Storage Service and storage state.
+    persistent failed polls, an invalid status response, or an expired deadline
+    has an unknown outcome. The raised ``AsyncOutcomeUnknown`` retains the Async
+    ID and warns callers not to submit duplicate work before reconciling Storage
+    Service and storage state.
 
     All raised client errors remain instances of
     ``requests.exceptions.RequestException`` for caller compatibility.
@@ -394,6 +395,17 @@ def wait_for_async(response, *, operation):
         LOGGER.error("%s", err)
         raise err
 
+    def raise_outcome_unknown(reason, *, cause):
+        err = AsyncOutcomeUnknown(
+            operation=operation,
+            async_id=async_id,
+            poll_url=poll_url,
+            elapsed_seconds=elapsed_seconds(),
+            reason=reason,
+        )
+        LOGGER.error("%s", err)
+        raise err from cause
+
     while True:
         remaining_seconds = deadline_at - time.monotonic()
         if remaining_seconds <= 0:
@@ -407,40 +419,66 @@ def wait_for_async(response, *, operation):
             poll_url,
             remaining_seconds,
         )
+        completed = False
         try:
             poll_response = _storage_api_session(
                 timeout=min(ASYNC_POLL_TIMEOUT_SECONDS, remaining_seconds)
             ).get(poll_url)
             poll_response.raise_for_status()
-            payload = poll_response.json()
-            completed = payload["completed"]
-            if completed:
-                was_error = payload["was_error"]
-                if was_error:
-                    remote_error = payload["error"]
-                    remote_error_code = payload.get("error_code")
-                else:
-                    result = payload["result"]
-        except (
-            requests.exceptions.RequestException,
-            KeyError,
-            TypeError,
-            ValueError,
-        ) as exc:
+        except requests.exceptions.RequestException as exc:
             status_code = getattr(getattr(exc, "response", None), "status_code", None)
             if status_code == 404:
-                reason = "the Storage Service status resource returned HTTP 404"
-            else:
-                reason = f"the Storage Service status request failed: {exc}"
-            err = AsyncOutcomeUnknown(
-                operation=operation,
-                async_id=async_id,
-                poll_url=poll_url,
-                elapsed_seconds=elapsed_seconds(),
-                reason=reason,
+                raise_outcome_unknown(
+                    "the Storage Service status resource returned HTTP 404",
+                    cause=exc,
+                )
+
+            retryable = isinstance(
+                exc,
+                (
+                    requests.exceptions.ChunkedEncodingError,
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout,
+                ),
+            ) or (
+                status_code is not None
+                and (status_code in {408, 429} or 500 <= status_code < 600)
             )
-            LOGGER.error("%s", err)
-            raise err from exc
+            if not retryable:
+                if status_code is None:
+                    reason = f"the Storage Service status request failed: {exc}"
+                else:
+                    reason = (
+                        "the Storage Service status request returned "
+                        f"HTTP {status_code}"
+                    )
+                raise_outcome_unknown(
+                    reason,
+                    cause=exc,
+                )
+
+            LOGGER.warning(
+                "Storage Service status request for async operation %s failed "
+                "transiently and will be retried: %s",
+                async_id,
+                exc,
+            )
+        else:
+            try:
+                payload = poll_response.json()
+                completed = payload["completed"]
+                if completed:
+                    was_error = payload["was_error"]
+                    if was_error:
+                        remote_error = payload["error"]
+                        remote_error_code = payload.get("error_code")
+                    else:
+                        result = payload["result"]
+            except (KeyError, TypeError, ValueError) as exc:
+                raise_outcome_unknown(
+                    f"the Storage Service status response was invalid: {exc}",
+                    cause=exc,
+                )
 
         if not completed:
             remaining_seconds = deadline_at - time.monotonic()

--- a/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.artefactual.py
+++ b/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.artefactual.py
@@ -1,0 +1,129 @@
+"""Test Storage Service
+
+Tests for the Archivematica Common Storage Service helpers.
+"""
+
+import json
+from unittest import mock
+
+import pytest
+from requests import Response
+
+from archivematica.archivematicaCommon.storageService import (
+    location_description_from_slug,
+)
+from archivematica.archivematicaCommon.storageService import request_file_deletion
+from archivematica.archivematicaCommon.storageService import (
+    retrieve_storage_location_description,
+)
+
+
+def mock_response(status_code, content_type, content):
+    response = Response()
+    response.status_code = status_code
+    response.headers["content-type"] = content_type
+    response.status = "Mocked status value"
+    response._content = json.dumps(content).encode("utf8")
+    return response
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status_code,content_type,expected_result",
+    [
+        (200, "application/json", {"description": "a description", "path": "/a/path/"}),
+        (200, "application/gzip", {}),
+        (204, "x-application/mocked", {}),
+        (400, "x-application/mocked", {}),
+        (500, "x-application/mocked", {}),
+        (0, "", {}),
+    ],
+)
+@mock.patch("archivematica.archivematicaCommon.storageService._storage_service_url")
+@mock.patch("requests.Session.get")
+def test_location_desc_from_slug(
+    get, _storage_service_url, status_code, content_type, expected_result
+):
+    """Test location description from slug
+
+    Rudimentary test to ensure that we're returning something that
+    implements .get() for any potential return from this function. And
+    that we get something sensible for unexpected status codes.
+    """
+
+    get.return_value = mock_response(status_code, content_type, expected_result)
+    res = location_description_from_slug("mock_uri")
+    assert res == expected_result, f"Unexpected result for status test: {status_code}"
+
+
+@pytest.mark.parametrize(
+    "slug,return_value,expected_result",
+    [
+        (
+            "/api/v2/location/3e796bef-0d56-4471-8700-eeb256859811/",
+            {"description": "a description"},
+            "a description",
+        ),
+        (
+            "/api/v2/location/default/AS/",
+            {"description": None, "path": "/path/one/"},
+            "/path/one/",
+        ),
+        (
+            "/api/v2/location/e0a9558c-ae00-4e39-886d-2a38bba98c72/",
+            {"path": "/path/two"},
+            "/path/two",
+        ),
+        (
+            "/api/v2/location/e0a9558c-ae00-4e39-886d-2a38bba98c72/",
+            {"description": "a description", "path": "/path/three"},
+            "a description",
+        ),
+        ("/api/v2/location/fd46760b-567f-4c17-a2f4-a05e79074932/", {}, ""),
+    ],
+)
+@mock.patch(
+    "archivematica.archivematicaCommon.storageService.location_description_from_slug"
+)
+def test_retrieve_storage_location(
+    location_description_from_slug, slug, return_value, expected_result
+):
+    """Test retrieve storage location
+
+    Ensure that we're able to retrieve the resource description for the
+    storage service from our request to the storage service. We should
+    be able to retrieve a 'description' or "path" or "" (blank string)
+    in that order, depending on the response, i.e. if a user hasn't
+    specified a description, we should be able to fall-back on something
+    else. Likewise if we receive something unexpected.
+    """
+    location_description_from_slug.return_value = return_value
+    res = retrieve_storage_location_description(slug)
+    assert res == expected_result
+
+
+@pytest.mark.django_db
+@mock.patch("archivematica.archivematicaCommon.storageService._storage_api_session")
+@mock.patch(
+    "archivematica.archivematicaCommon.storageService._storage_service_url",
+    return_value="http://ss/",
+)
+def test_request_file_deletion_handles_non_json_response(
+    _storage_service_url, _storage_api_session
+):
+    response = Response()
+    response.status_code = 404
+    response.headers["content-type"] = "text/plain"
+    response._content = b"Not Found"
+    session = mock.Mock()
+    session.post.return_value = response
+    _storage_api_session.return_value = session
+
+    result = request_file_deletion(
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        0,
+        "archivematica@example.com",
+        "testing",
+    )
+
+    assert result == {"error": True, "message": "Not Found", "status": 404}

--- a/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.wellcome.py
+++ b/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.wellcome.py
@@ -1,0 +1,356 @@
+"""Test Storage Service
+
+Tests for the Archivematica Common Storage Service helpers.
+"""
+
+import json
+from unittest import mock
+
+import pytest
+from requests import Response
+
+from archivematica.archivematicaCommon import storageService
+from archivematica.archivematicaCommon.storageService import (
+    location_description_from_slug,
+)
+from archivematica.archivematicaCommon.storageService import request_file_deletion
+from archivematica.archivematicaCommon.storageService import (
+    retrieve_storage_location_description,
+)
+
+
+def mock_response(status_code, content_type, content):
+    response = Response()
+    response.status_code = status_code
+    response.headers["content-type"] = content_type
+    response.status = "Mocked status value"
+    response._content = json.dumps(content).encode("utf8")
+    return response
+
+
+def async_response(location="/api/v2/async/158/"):
+    response = Response()
+    response.status_code = 202
+    response.headers["Location"] = location
+    return response
+
+
+def async_status_response(payload=None, status_code=200):
+    response = Response()
+    response.status_code = status_code
+    response.url = "http://ss/api/v2/async/158/"
+    response.headers["content-type"] = "application/json"
+    response._content = json.dumps(payload or {}).encode("utf8")
+    return response
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    clock = FakeClock()
+    monkeypatch.setattr(storageService.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(storageService.time, "sleep", clock.sleep)
+    return clock
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "status_code,content_type,expected_result",
+    [
+        (200, "application/json", {"description": "a description", "path": "/a/path/"}),
+        (200, "application/gzip", {}),
+        (204, "x-application/mocked", {}),
+        (400, "x-application/mocked", {}),
+        (500, "x-application/mocked", {}),
+        (0, "", {}),
+    ],
+)
+@mock.patch("archivematica.archivematicaCommon.storageService._storage_service_url")
+@mock.patch("requests.Session.get")
+def test_location_desc_from_slug(
+    get, _storage_service_url, status_code, content_type, expected_result
+):
+    """Test location description from slug
+
+    Rudimentary test to ensure that we're returning something that
+    implements .get() for any potential return from this function. And
+    that we get something sensible for unexpected status codes.
+    """
+
+    get.return_value = mock_response(status_code, content_type, expected_result)
+    res = location_description_from_slug("mock_uri")
+    assert res == expected_result, f"Unexpected result for status test: {status_code}"
+
+
+@pytest.mark.parametrize(
+    "slug,return_value,expected_result",
+    [
+        (
+            "/api/v2/location/3e796bef-0d56-4471-8700-eeb256859811/",
+            {"description": "a description"},
+            "a description",
+        ),
+        (
+            "/api/v2/location/default/AS/",
+            {"description": None, "path": "/path/one/"},
+            "/path/one/",
+        ),
+        (
+            "/api/v2/location/e0a9558c-ae00-4e39-886d-2a38bba98c72/",
+            {"path": "/path/two"},
+            "/path/two",
+        ),
+        (
+            "/api/v2/location/e0a9558c-ae00-4e39-886d-2a38bba98c72/",
+            {"description": "a description", "path": "/path/three"},
+            "a description",
+        ),
+        ("/api/v2/location/fd46760b-567f-4c17-a2f4-a05e79074932/", {}, ""),
+    ],
+)
+@mock.patch(
+    "archivematica.archivematicaCommon.storageService.location_description_from_slug"
+)
+def test_retrieve_storage_location(
+    location_description_from_slug, slug, return_value, expected_result
+):
+    """Test retrieve storage location
+
+    Ensure that we're able to retrieve the resource description for the
+    storage service from our request to the storage service. We should
+    be able to retrieve a 'description' or "path" or "" (blank string)
+    in that order, depending on the response, i.e. if a user hasn't
+    specified a description, we should be able to fall-back on something
+    else. Likewise if we receive something unexpected.
+    """
+    location_description_from_slug.return_value = return_value
+    res = retrieve_storage_location_description(slug)
+    assert res == expected_result
+
+
+@pytest.mark.django_db
+@mock.patch("archivematica.archivematicaCommon.storageService._storage_api_session")
+@mock.patch(
+    "archivematica.archivematicaCommon.storageService._storage_service_url",
+    return_value="http://ss/",
+)
+def test_request_file_deletion_handles_non_json_response(
+    _storage_service_url, _storage_api_session
+):
+    response = Response()
+    response.status_code = 404
+    response.headers["content-type"] = "text/plain"
+    response._content = b"Not Found"
+    session = mock.Mock()
+    session.post.return_value = response
+    _storage_api_session.return_value = session
+
+    result = request_file_deletion(
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        0,
+        "archivematica@example.com",
+        "testing",
+    )
+
+    assert result == {"error": True, "message": "Not Found", "status": 404}
+
+
+def test_async_observation_deadline_is_24_hours():
+    assert storageService.ASYNC_OBSERVATION_DEADLINE_SECONDS == 24 * 60 * 60
+
+
+def test_wait_for_async_returns_result_with_bounded_poll_timeouts(
+    monkeypatch, fake_clock
+):
+    monkeypatch.setattr(storageService, "ASYNC_OBSERVATION_DEADLINE_SECONDS", 10)
+    session = mock.Mock()
+    session.get.side_effect = [
+        async_status_response({"completed": False}),
+        async_status_response(
+            {"completed": True, "was_error": False, "result": {"uuid": "file"}}
+        ),
+    ]
+    storage_api_session = mock.Mock(return_value=session)
+    monkeypatch.setattr(storageService, "_storage_api_session", storage_api_session)
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    result = storageService.wait_for_async(async_response(), operation="copy_files")
+
+    assert result == {"uuid": "file"}
+    assert fake_clock.now == 2
+    assert storage_api_session.call_args_list == [
+        mock.call(timeout=10),
+        mock.call(timeout=8),
+    ]
+
+
+def test_wait_for_async_stops_at_observation_deadline(monkeypatch, fake_clock, caplog):
+    monkeypatch.setattr(storageService, "ASYNC_OBSERVATION_DEADLINE_SECONDS", 3)
+    session = mock.Mock()
+    session.get.return_value = async_status_response({"completed": False})
+    storage_api_session = mock.Mock(return_value=session)
+    monkeypatch.setattr(storageService, "_storage_api_session", storage_api_session)
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    with pytest.raises(storageService.AsyncObservationDeadlineExceeded) as exc_info:
+        storageService.wait_for_async(async_response(), operation="copy_files")
+
+    assert fake_clock.now == 3
+    assert exc_info.value.async_id == "158"
+    assert exc_info.value.deadline_seconds == 3
+    assert "unknown outcome" in str(exc_info.value)
+    assert "Do not submit it again" in str(exc_info.value)
+    assert "Storage Service async operation 158" in caplog.text
+    assert storage_api_session.call_args_list == [
+        mock.call(timeout=3),
+        mock.call(timeout=1),
+    ]
+    assert session.get.call_count == 2
+
+
+def test_wait_for_async_reports_missing_status_as_unknown(monkeypatch, fake_clock):
+    session = mock.Mock()
+    session.get.return_value = async_status_response(status_code=404)
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    with pytest.raises(storageService.AsyncOutcomeUnknown) as exc_info:
+        storageService.wait_for_async(async_response(), operation="create_file")
+
+    assert not isinstance(
+        exc_info.value, storageService.AsyncObservationDeadlineExceeded
+    )
+    assert exc_info.value.async_id == "158"
+    assert "returned HTTP 404" in str(exc_info.value)
+    assert "unknown outcome" in str(exc_info.value)
+
+
+def test_wait_for_async_reports_poll_failure_as_unknown(monkeypatch, fake_clock):
+    session = mock.Mock()
+    session.get.side_effect = storageService.requests.ConnectionError("unavailable")
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    with pytest.raises(storageService.AsyncOutcomeUnknown) as exc_info:
+        storageService.wait_for_async(async_response(), operation="create_file")
+
+    assert exc_info.value.async_id == "158"
+    assert "status request failed: unavailable" in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, storageService.requests.ConnectionError)
+
+
+def test_wait_for_async_preserves_reported_terminal_failure(monkeypatch, fake_clock):
+    session = mock.Mock()
+    session.get.return_value = async_status_response(
+        {"completed": True, "was_error": True, "error": "copy failed"}
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    with pytest.raises(storageService.WaitForAsyncError) as exc_info:
+        storageService.wait_for_async(async_response(), operation="copy_files")
+
+    assert not isinstance(exc_info.value, storageService.AsyncOutcomeUnknown)
+    assert "reported failure: copy failed" in str(exc_info.value)
+
+
+def test_copy_files_does_not_resubmit_unknown_operation(monkeypatch):
+    monkeypatch.setattr(storageService.am, "get_setting", lambda _name: "dashboard")
+    monkeypatch.setattr(
+        storageService, "get_pipeline", lambda _uuid: {"resource_uri": "/pipeline/1/"}
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+    response = async_response()
+    session = mock.Mock()
+    session.post.return_value = response
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    outcome_unknown = storageService.AsyncOutcomeUnknown(
+        operation="copy_files",
+        async_id="158",
+        poll_url="http://ss/api/v2/async/158/",
+        elapsed_seconds=1,
+        reason="test",
+    )
+    wait_for_async = mock.Mock(side_effect=outcome_unknown)
+    monkeypatch.setattr(storageService, "wait_for_async", wait_for_async)
+
+    result, error = storageService.copy_files(
+        {"resource_uri": "/location/source/"},
+        {"uuid": "destination"},
+        [{"source": "source", "destination": "destination"}],
+    )
+
+    assert result is None
+    assert error is outcome_unknown
+    session.post.assert_called_once()
+    wait_for_async.assert_called_once_with(response, operation="copy_files")
+
+
+def test_create_file_does_not_resubmit_unknown_operation(monkeypatch):
+    monkeypatch.setattr(storageService.am, "get_setting", lambda _name: "dashboard")
+    monkeypatch.setattr(
+        storageService, "get_pipeline", lambda _uuid: {"resource_uri": "/pipeline/1/"}
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+    response = async_response()
+    session = mock.Mock()
+    session.post.return_value = response
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    outcome_unknown = storageService.AsyncOutcomeUnknown(
+        operation="create_file",
+        async_id="158",
+        poll_url="http://ss/api/v2/async/158/",
+        elapsed_seconds=1,
+        reason="test",
+    )
+    wait_for_async = mock.Mock(side_effect=outcome_unknown)
+    monkeypatch.setattr(storageService, "wait_for_async", wait_for_async)
+
+    with pytest.raises(storageService.AsyncOutcomeUnknown) as exc_info:
+        storageService.create_file(
+            "package-uuid",
+            "/location/source/",
+            "source-path",
+            "/location/current/",
+            "current-path",
+            "AIP",
+            123,
+        )
+
+    assert exc_info.value is outcome_unknown
+    session.post.assert_called_once()
+    wait_for_async.assert_called_once_with(response, operation="create_file")

--- a/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.wellcome.py
+++ b/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.wellcome.py
@@ -297,9 +297,67 @@ def test_wait_for_async_reports_terminal_interruption_as_unknown(
     assert "Storage Service reported an interrupted operation" in exc_info.value.reason
 
 
-def test_wait_for_async_reports_poll_failure_as_unknown(monkeypatch, fake_clock):
+@pytest.mark.parametrize(
+    "transient_failure",
+    [
+        storageService.requests.ConnectionError("unavailable"),
+        storageService.requests.exceptions.ChunkedEncodingError("incomplete response"),
+        async_status_response(status_code=502),
+    ],
+    ids=["connection", "chunked", "502"],
+)
+def test_wait_for_async_retries_transient_poll_failure(
+    monkeypatch, fake_clock, caplog, transient_failure
+):
+    session = mock.Mock()
+    session.get.side_effect = [
+        transient_failure,
+        async_status_response(
+            {"completed": True, "was_error": False, "result": {"uuid": "file"}}
+        ),
+    ]
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    result = storageService.wait_for_async(async_response(), operation="create_file")
+
+    assert result == {"uuid": "file"}
+    assert fake_clock.now == 2
+    assert session.get.call_count == 2
+    assert "failed transiently and will be retried" in caplog.text
+
+
+def test_wait_for_async_reports_persistent_poll_failure_at_deadline(
+    monkeypatch, fake_clock, caplog
+):
+    monkeypatch.setattr(storageService, "ASYNC_OBSERVATION_DEADLINE_SECONDS", 3)
     session = mock.Mock()
     session.get.side_effect = storageService.requests.ConnectionError("unavailable")
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    with pytest.raises(storageService.AsyncObservationDeadlineExceeded) as exc_info:
+        storageService.wait_for_async(async_response(), operation="create_file")
+
+    assert exc_info.value.async_id == "158"
+    assert fake_clock.now == 3
+    assert session.get.call_count == 2
+    assert "failed transiently and will be retried" in caplog.text
+
+
+def test_wait_for_async_reports_invalid_status_response_as_unknown(
+    monkeypatch, fake_clock
+):
+    session = mock.Mock()
+    session.get.return_value = async_status_response({"completed": True})
     monkeypatch.setattr(
         storageService, "_storage_api_session", mock.Mock(return_value=session)
     )
@@ -311,8 +369,9 @@ def test_wait_for_async_reports_poll_failure_as_unknown(monkeypatch, fake_clock)
         storageService.wait_for_async(async_response(), operation="create_file")
 
     assert exc_info.value.async_id == "158"
-    assert "status request failed: unavailable" in str(exc_info.value)
-    assert isinstance(exc_info.value.__cause__, storageService.requests.ConnectionError)
+    assert "status response was invalid" in str(exc_info.value)
+    assert "status request failed" not in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, KeyError)
 
 
 def test_wait_for_async_preserves_reported_terminal_failure(monkeypatch, fake_clock):

--- a/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.wellcome.py
+++ b/archivematica-apps/archivematica/overlay/tests/archivematicaCommon/test_storage_service.wellcome.py
@@ -44,6 +44,24 @@ def async_status_response(payload=None, status_code=200):
     return response
 
 
+@pytest.fixture(params=["missing_status", "interrupted"], ids=["404", "interrupted"])
+def unknown_async_status_response(request):
+    if request.param == "missing_status":
+        return async_status_response(status_code=404)
+    return async_status_response(
+        {
+            "completed": True,
+            "was_error": True,
+            "error_code": "async_operation_interrupted",
+            "error": (
+                "<class 'RuntimeError'>: The asynchronous operation was "
+                "interrupted after its heartbeat expired. Its final outcome is "
+                "unknown; do not retry it automatically."
+            ),
+        }
+    )
+
+
 class FakeClock:
     def __init__(self):
         self.now = 0.0
@@ -243,6 +261,42 @@ def test_wait_for_async_reports_missing_status_as_unknown(monkeypatch, fake_cloc
     assert "unknown outcome" in str(exc_info.value)
 
 
+def test_wait_for_async_reports_terminal_interruption_as_unknown(
+    monkeypatch, fake_clock
+):
+    interrupted_error = "The wording of this message can change."
+    session = mock.Mock()
+    terminal_payload = {
+        "completed": True,
+        "was_error": True,
+        "error_code": "async_operation_interrupted",
+        "error": interrupted_error,
+    }
+    session.get.side_effect = [
+        async_status_response({"completed": False}),
+        async_status_response(terminal_payload),
+    ]
+    monkeypatch.setattr(
+        storageService, "_storage_api_session", mock.Mock(return_value=session)
+    )
+    monkeypatch.setattr(
+        storageService, "_storage_service_url", lambda: "http://ss/api/v2/"
+    )
+
+    with pytest.raises(storageService.AsyncOutcomeUnknown) as exc_info:
+        storageService.wait_for_async(async_response(), operation="create_file")
+
+    assert not isinstance(
+        exc_info.value, storageService.AsyncObservationDeadlineExceeded
+    )
+    assert exc_info.value.operation == "create_file"
+    assert exc_info.value.async_id == "158"
+    assert exc_info.value.poll_url == "http://ss/api/v2/async/158/"
+    assert exc_info.value.elapsed_seconds == 2
+    assert interrupted_error in exc_info.value.reason
+    assert "Storage Service reported an interrupted operation" in exc_info.value.reason
+
+
 def test_wait_for_async_reports_poll_failure_as_unknown(monkeypatch, fake_clock):
     session = mock.Mock()
     session.get.side_effect = storageService.requests.ConnectionError("unavailable")
@@ -264,7 +318,12 @@ def test_wait_for_async_reports_poll_failure_as_unknown(monkeypatch, fake_clock)
 def test_wait_for_async_preserves_reported_terminal_failure(monkeypatch, fake_clock):
     session = mock.Mock()
     session.get.return_value = async_status_response(
-        {"completed": True, "was_error": True, "error": "copy failed"}
+        {
+            "completed": True,
+            "was_error": True,
+            "error_code": None,
+            "error": "copy failed for an unknown reason",
+        }
     )
     monkeypatch.setattr(
         storageService, "_storage_api_session", mock.Mock(return_value=session)
@@ -277,10 +336,12 @@ def test_wait_for_async_preserves_reported_terminal_failure(monkeypatch, fake_cl
         storageService.wait_for_async(async_response(), operation="copy_files")
 
     assert not isinstance(exc_info.value, storageService.AsyncOutcomeUnknown)
-    assert "reported failure: copy failed" in str(exc_info.value)
+    assert "reported failure: copy failed for an unknown reason" in str(exc_info.value)
 
 
-def test_copy_files_does_not_resubmit_unknown_operation(monkeypatch):
+def test_copy_files_does_not_resubmit_unknown_operation(
+    monkeypatch, unknown_async_status_response
+):
     monkeypatch.setattr(storageService.am, "get_setting", lambda _name: "dashboard")
     monkeypatch.setattr(
         storageService, "get_pipeline", lambda _uuid: {"resource_uri": "/pipeline/1/"}
@@ -291,18 +352,10 @@ def test_copy_files_does_not_resubmit_unknown_operation(monkeypatch):
     response = async_response()
     session = mock.Mock()
     session.post.return_value = response
+    session.get.return_value = unknown_async_status_response
     monkeypatch.setattr(
         storageService, "_storage_api_session", mock.Mock(return_value=session)
     )
-    outcome_unknown = storageService.AsyncOutcomeUnknown(
-        operation="copy_files",
-        async_id="158",
-        poll_url="http://ss/api/v2/async/158/",
-        elapsed_seconds=1,
-        reason="test",
-    )
-    wait_for_async = mock.Mock(side_effect=outcome_unknown)
-    monkeypatch.setattr(storageService, "wait_for_async", wait_for_async)
 
     result, error = storageService.copy_files(
         {"resource_uri": "/location/source/"},
@@ -311,12 +364,13 @@ def test_copy_files_does_not_resubmit_unknown_operation(monkeypatch):
     )
 
     assert result is None
-    assert error is outcome_unknown
+    assert isinstance(error, storageService.AsyncOutcomeUnknown)
     session.post.assert_called_once()
-    wait_for_async.assert_called_once_with(response, operation="copy_files")
 
 
-def test_create_file_does_not_resubmit_unknown_operation(monkeypatch):
+def test_create_file_does_not_resubmit_unknown_operation(
+    monkeypatch, unknown_async_status_response
+):
     monkeypatch.setattr(storageService.am, "get_setting", lambda _name: "dashboard")
     monkeypatch.setattr(
         storageService, "get_pipeline", lambda _uuid: {"resource_uri": "/pipeline/1/"}
@@ -327,18 +381,10 @@ def test_create_file_does_not_resubmit_unknown_operation(monkeypatch):
     response = async_response()
     session = mock.Mock()
     session.post.return_value = response
+    session.get.return_value = unknown_async_status_response
     monkeypatch.setattr(
         storageService, "_storage_api_session", mock.Mock(return_value=session)
     )
-    outcome_unknown = storageService.AsyncOutcomeUnknown(
-        operation="create_file",
-        async_id="158",
-        poll_url="http://ss/api/v2/async/158/",
-        elapsed_seconds=1,
-        reason="test",
-    )
-    wait_for_async = mock.Mock(side_effect=outcome_unknown)
-    monkeypatch.setattr(storageService, "wait_for_async", wait_for_async)
 
     with pytest.raises(storageService.AsyncOutcomeUnknown) as exc_info:
         storageService.create_file(
@@ -351,6 +397,7 @@ def test_create_file_does_not_resubmit_unknown_operation(monkeypatch):
             123,
         )
 
-    assert exc_info.value is outcome_unknown
+    assert not isinstance(
+        exc_info.value, storageService.AsyncObservationDeadlineExceeded
+    )
     session.post.assert_called_once()
-    wait_for_async.assert_called_once_with(response, operation="create_file")


### PR DESCRIPTION
## What does this change?

`wait_for_async` could poll forever, tying up MCPServer workers (see #176). This adds a 24-hour deadline for async copy and create-file operations, treats timeouts, 404s, and interrupted operations as unknown outcomes, preserves the Async ID, and prevents automatic resubmission.

## How to test

Deploy the branch to staging and run a small transfer through to AIP storage. Confirm that normal async operations complete successfully. For the failure path, validate this when the condition next occurs naturally in staging: an async operation exceeds the observation deadline or is interrupted. Then verify that the transfer reports an unknown outcome, the worker is released, the Async ID is logged, and no duplicate request is submitted.

## How can we measure success?

Stalled operations release MCPServer workers after the deadline, logs retain the Async ID for reconciliation, and unknown outcomes are not resubmitted automatically.

## Have we considered potential risks?

The deadline stops Archivematica polling but does not cancel the remote operation, which may finish later. Before retrying, use the logged Async ID to check its status and confirm whether any side effects occurred. Operations exceeding 24 hours require manual reconciliation.

Refs #176
