### PR TITLE
Use Archivematica idempotency keys

### DIFF
--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -14,7 +14,12 @@ A transfer package is a zip file containing the files, plus some metadata (inclu
 ```mermaid
 graph TD
     A[User uploads package<br/>to S3] -->|S3 PutObject notification| L{Lambda checks package<br/>has correct structure<br/>and metadata}
-    L -->|passes checks| S[trigger Archivematica transfer,<br/>upload 'success' log and<br/>tag S3 object]
+    L -->|passes checks| K[derive idempotency key<br/>from the S3 event]
+    K --> S[trigger Archivematica transfer<br/>with Idempotency-Key]
+    S --> C[tag S3 object and upload<br/>a stable 'success' log]
+    S -->|temporary failure| R[fail the invocation so<br/>Lambda retries the event]
+    C -->|temporary failure| R
+    R --> L
     L -->|fails checks| F[upload 'failed' log]
 
     classDef failedNode fill:#e01b2f,stroke:#e01b2f,fill-opacity:0.15
@@ -38,6 +43,27 @@ It records a success/fail result by uploading a small log file alongside the ori
 
 If it starts a transfer successfully, it tags the S3 object with the transfer ID.
 The [transfer monitor Lambda](../transfer_monitor) uses these tags to report Archivematica successes and failures and remove successfully stored packages from the transfer bucket.
+
+## Idempotency
+
+S3 and Lambda can deliver the same notification more than once.
+The Lambda derives a SHA-256 identity from the notification's bucket, decoded object key, event type, sequencer, and version ID when present.
+It sends that identity to Archivematica in the `Idempotency-Key` header on every attempt.
+
+Archivematica returns the original Transfer UUID when the same request and key are replayed, including when an earlier response was lost after the Transfer was accepted.
+A genuine replacement upload has a new S3 sequencer or version ID, so it receives a new key and starts a new Transfer.
+
+Archivematica transport errors, server errors, and retryable HTTP responses fail the invocation, as do failures writing S3 success feedback.
+Lambda can then redeliver the event without creating another Transfer.
+Permanent submission errors write a failed user log and do not retry.
+Package tags include the stable S3 event time, and user log names include a readable event timestamp and an event identity suffix so a retry overwrites the same log instead of creating a duplicate.
+Invalid packages and permanent transfer-source configuration errors also write a failed user log and do not retry.
+
+The header is optional and ignored by older Archivematica versions, but deploying this retry behaviour with those versions is unsafe because an uncertain submission can create duplicate Transfers.
+Deploy idempotency-aware Dashboard and MCPServer images before deploying this Lambda version in an environment.
+Safe replay guarantees apply only when the request is handled by Dashboard and MCPServer versions which support idempotent package submission.
+During a mixed-version rollout, attempts handled by an older instance can still create duplicate Transfers.
+Newer Archivematica versions retain keys for 90 days, which covers Lambda retries and events retained in the Lambda dead-letter queue.
 
 
 

--- a/lambdas/s3_start_transfer/src/archivematica.py
+++ b/lambdas/s3_start_transfer/src/archivematica.py
@@ -18,11 +18,12 @@ class StoragePathException(Exception):
     pass
 
 
-def am_api_post_json(api_path, data):
+def am_api_post_json(api_path, data, headers=None):
     """
     POST json to the Archivematica API
     :param api_path: URL path to request (without hostname, e.g. /api/v2/location/)
     :param data: Dict of data to post
+    :param headers: Additional HTTP headers to include in the request
     :returns: dict of json data returned by request
     """
     am_url = os.environ["ARCHIVEMATICA_URL"]
@@ -37,7 +38,11 @@ def am_api_post_json(api_path, data):
     request = urllib.request.Request(
         url,
         data=data,
-        headers={**am_headers, "Content-Type": "application/json"},
+        headers={
+            **am_headers,
+            "Content-Type": "application/json",
+            **(headers or {}),
+        },
         method="POST",
     )
     response = urllib.request.urlopen(request)
@@ -158,12 +163,20 @@ def find_matching_path(locations, bucket, directory, key):
     raise StoragePathException("Unable to find location for %s:%s" % (bucket, key))
 
 
-def start_transfer(name, path, processing_config, accession_number=None):
+def start_transfer(
+    name,
+    path,
+    processing_config,
+    *,
+    idempotency_key,
+    accession_number=None,
+):
     """
     Start an Archivematica transfer using the automated workflow
 
     :param name: Name of transfer
-    :param key: Path of transfer, of the form b'<location_uuid>:<target_path>'
+    :param path: Path of transfer, of the form b'<location_uuid>:<target_path>'
+    :param idempotency_key: Stable identity reused for every submission attempt
 
     :returns: transfer uuid
     """
@@ -180,7 +193,11 @@ def start_transfer(name, path, processing_config, accession_number=None):
     if accession_number is not None:
         data["accession"] = accession_number
 
-    response_json = am_api_post_json("/api/v2beta/package", data)
+    response_json = am_api_post_json(
+        "/api/v2beta/package",
+        data,
+        headers={"Idempotency-Key": idempotency_key},
+    )
     if "error" in response_json:
         raise StartTransferException(
             "Error starting transfer: %s" % response_json["message"]

--- a/lambdas/s3_start_transfer/src/idempotency.py
+++ b/lambdas/s3_start_transfer/src/idempotency.py
@@ -1,0 +1,42 @@
+import dataclasses
+import hashlib
+import json
+import urllib.parse
+
+
+@dataclasses.dataclass(frozen=True)
+class S3EventIdentity:
+    bucket: str
+    object_key: str
+    event_name: str
+    sequencer: str
+    event_time: str
+    version_id: str | None = None
+
+    @classmethod
+    def from_record(cls, record):
+        s3_object = record["s3"]["object"]
+
+        return cls(
+            bucket=record["s3"]["bucket"]["name"],
+            object_key=urllib.parse.unquote_plus(s3_object["key"], encoding="utf-8"),
+            event_name=record["eventName"],
+            sequencer=s3_object["sequencer"],
+            event_time=record["eventTime"],
+            version_id=s3_object.get("versionId"),
+        )
+
+    @property
+    def event_id(self):
+        identity = {
+            "bucket": self.bucket,
+            "event_name": self.event_name,
+            "object_key": self.object_key,
+            "sequencer": self.sequencer,
+            "version_id": self.version_id,
+        }
+        encoded_identity = json.dumps(
+            identity, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+
+        return hashlib.sha256(encoded_identity).hexdigest()

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -4,7 +4,7 @@ import io
 import os
 import os.path
 import traceback
-import urllib.parse
+import urllib.error
 import zipfile
 
 import boto3
@@ -12,6 +12,7 @@ import boto3
 import archivematica
 from archivematica import choose_processing_config
 from big_s3 import S3File
+from idempotency import S3EventIdentity
 from log_handler import Logger
 from verify_transfer_packages import (
     VerificationFailure,
@@ -24,11 +25,13 @@ from verify_transfer_packages import (
 )
 
 
-def _write_log(sess, logger, bucket, key, result, tags=None):
+_RETRYABLE_HTTP_STATUS_CODES = {408, 409, 425, 429}
+
+
+def _write_log(sess, logger, bucket, key, result, log_id, event_time, tags=None):
     s3 = sess.client("s3")
 
-    timestamp = dt.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    log_key = ".".join([key, result, timestamp, "log"])
+    log_key = ".".join([key, result, event_time, log_id[:12], "log"])
 
     print(f"Writing user log to s3://{bucket}/{log_key}")
 
@@ -58,7 +61,7 @@ def _write_log(sess, logger, bucket, key, result, tags=None):
         )
 
 
-def verify_s3_package(sess, *, logger, bucket, key):
+def verify_s3_package(sess, *, logger, bucket, key, log_id, event_time):
     print(f"Running verifications on s3://{bucket}/{key}")
     s3 = sess.resource("s3")
     s3_object = s3.Object(bucket, key)
@@ -80,7 +83,15 @@ def verify_s3_package(sess, *, logger, bucket, key):
 
     with zipfile.ZipFile(s3_file) as zf:
         if not verify_package(logger=logger, zip_file=zf, verifications=verifications):
-            _write_log(sess, logger, bucket=bucket, key=key, result="failed")
+            _write_log(
+                sess,
+                logger,
+                bucket=bucket,
+                key=key,
+                result="failed",
+                log_id=log_id,
+                event_time=event_time,
+            )
             raise VerificationFailure("One of the verifications failed!")
 
 
@@ -105,7 +116,40 @@ def get_identifiers(*, s3, logger, bucket, key):
         }
 
 
-def run_transfer(sess, *, bucket, key):
+def _record_start_failure(sess, logger, *, bucket, key, err, log_id, event_time):
+    logger.write(f"Error starting transfer: {err}")
+    logger.write("Ask somebody to check the CloudWatch logs for more info")
+    _write_log(
+        sess,
+        logger,
+        bucket=bucket,
+        key=key,
+        result="failed",
+        log_id=log_id,
+        event_time=event_time,
+    )
+
+    print(f"Error starting transfer for s3://{bucket}/{key}")
+
+
+def _record_package_failure(sess, logger, *, bucket, key, err, log_id, event_time):
+    logger.write(f"Unable to read transfer package: {err}")
+    _write_log(
+        sess,
+        logger,
+        bucket=bucket,
+        key=key,
+        result="failed",
+        log_id=log_id,
+        event_time=event_time,
+    )
+
+    print(f"Invalid transfer package in s3://{bucket}/{key}")
+
+
+def run_transfer(sess, *, event):
+    bucket = event.bucket
+    key = event.object_key
     logger = Logger()
 
     # Run some verifications on the object before we sent it to Archivematica.
@@ -117,7 +161,14 @@ def run_transfer(sess, *, bucket, key):
     # See https://github.com/wellcomecollection/platform/issues/4614
     try:
         try:
-            verify_s3_package(sess, logger=logger, bucket=bucket, key=key)
+            verify_s3_package(
+                sess,
+                logger=logger,
+                bucket=bucket,
+                key=key,
+                log_id=event.event_id,
+                event_time=event.event_time,
+            )
         except VerificationFailure:
             print(f"Verification error in s3://{bucket}/{key}")
             return
@@ -125,6 +176,17 @@ def run_transfer(sess, *, bucket, key):
         identifiers = get_identifiers(
             s3=sess.resource("s3"), logger=logger, bucket=bucket, key=key
         )
+    except (zipfile.BadZipFile, UnicodeDecodeError) as err:
+        _record_package_failure(
+            sess,
+            logger,
+            bucket=bucket,
+            key=key,
+            err=err,
+            log_id=event.event_id,
+            event_time=event.event_time,
+        )
+        return
     except NotImplementedError as err:
         if str(err) in {
             "compression type 9 (deflate64)",
@@ -141,79 +203,139 @@ def run_transfer(sess, *, bucket, key):
             print(f"Unable to decompress s3://{bucket}/{key}: {err}")
             return
 
-    # Now try to start a transfer in Archivematica.
+    # Finish the work which can safely be repeated before submitting the transfer.
     try:
         processing_config = choose_processing_config(key)
 
         directory, key_path = key.strip("/").split("/", 1)
+    except ValueError as err:
+        _record_start_failure(
+            sess,
+            logger,
+            bucket=bucket,
+            key=key,
+            err=err,
+            log_id=event.event_id,
+            event_time=event.event_time,
+        )
+        return
 
-        # Identify the file's location on the AM storage service
+    # Identify the file's location on the AM storage service. A missing matching
+    # path is a permanent configuration error; transport and service errors are
+    # allowed to fail the invocation so Lambda can retry them.
+    try:
         target_path = archivematica.get_target_path(
             bucket=bucket, directory=directory, key=key_path
         )
+    except archivematica.StoragePathException as err:
+        _record_start_failure(
+            sess,
+            logger,
+            bucket=bucket,
+            key=key,
+            err=err,
+            log_id=event.event_id,
+            event_time=event.event_time,
+        )
+        return
 
-        target_name = os.path.basename(key)
+    target_name = os.path.basename(key)
+    try:
         transfer_id = archivematica.start_transfer(
             name=target_name,
             path=target_path,
             processing_config=processing_config,
             accession_number=identifiers["accession_number"],
+            idempotency_key=event.event_id,
         )
-
-        tags = {
-            "Archivematica-TransferId": transfer_id,
-            "Archivematica-ProcessingConfig": processing_config,
-            "Archivematica-AccessionNumber": identifiers["accession_number"],
-            "Archivematica-CatalogueIdentifier": identifiers["dc.identifier"],
-            "Archivematica-TransferStartedAt": dt.datetime.now().isoformat(),
-        }
-
-        sess.client("s3").put_object_tagging(
-            Bucket=bucket,
-            Key=key,
-            Tagging={
-                "TagSet": [
-                    {"Key": key, "Value": value}
-                    for (key, value) in tags.items()
-                    if value is not None
-                ]
-            },
+    except archivematica.StartTransferException as err:
+        _record_start_failure(
+            sess,
+            logger,
+            bucket=bucket,
+            key=key,
+            err=err,
+            log_id=event.event_id,
+            event_time=event.event_time,
         )
-    except Exception as err:
-        logger.write(f"Error starting transfer: {err}")
-        logger.write("Ask somebody to check the CloudWatch logs for more info")
-        _write_log(sess, logger, bucket=bucket, key=key, result="failed")
+        return
+    except urllib.error.HTTPError as err:
+        if not 400 <= err.code < 500 or err.code in _RETRYABLE_HTTP_STATUS_CODES:
+            raise
+        _record_start_failure(
+            sess,
+            logger,
+            bucket=bucket,
+            key=key,
+            err=err,
+            log_id=event.event_id,
+            event_time=event.event_time,
+        )
+        return
 
-        print(f"Error starting transfer for s3://{bucket}/{key}")
-    else:
-        logger.write("Started successful transfer!")
-        logger.write(f"Archivematica transfer ID is {transfer_id}")
-        _write_log(sess, logger, bucket=bucket, key=key, result="success", tags=tags)
+    tags = {
+        "Archivematica-TransferId": transfer_id,
+        "Archivematica-ProcessingConfig": processing_config,
+        "Archivematica-AccessionNumber": identifiers["accession_number"],
+        "Archivematica-CatalogueIdentifier": identifiers["dc.identifier"],
+        "Archivematica-S3EventTime": event.event_time,
+    }
 
-        print("Started transfer {}".format(transfer_id))
+    sess.client("s3").put_object_tagging(
+        Bucket=bucket,
+        Key=key,
+        Tagging={
+            "TagSet": [
+                {"Key": key, "Value": value}
+                for (key, value) in tags.items()
+                if value is not None
+            ]
+        },
+    )
+
+    logger.write("Started successful transfer!")
+    logger.write(f"Archivematica transfer ID is {transfer_id}")
+    _write_log(
+        sess,
+        logger,
+        bucket=bucket,
+        key=key,
+        result="success",
+        tags=tags,
+        log_id=event.event_id,
+        event_time=event.event_time,
+    )
+
+    print("Started transfer {}".format(transfer_id))
 
 
 def main(event, context=None):
     sess = boto3.Session()
+    first_failure = None
 
     for record in event["Records"]:
-        # Get the object from the event and show its content type
-        bucket = record["s3"]["bucket"]["name"]
-        key = urllib.parse.unquote_plus(record["s3"]["object"]["key"], encoding="utf-8")
-
         try:
-            run_transfer(sess, bucket=bucket, key=key)
-        except Exception:
+            run_transfer(sess, event=S3EventIdentity.from_record(record))
+        except Exception as err:
             print(traceback.format_exc())
             print("Error thrown, skipping to next record...")
-            continue
+            if first_failure is None:
+                first_failure = err
+
+    if first_failure is not None:
+        raise first_failure
 
 
 if __name__ == "__main__":  # pragma: no cover
-    s3 = boto3.resource("s3")
+    sess = boto3.Session()
 
     run_transfer(
-        s3,
-        bucket="wellcomecollection-archivematica-transfer-source",
-        key="born-digital-accessions/WT_B_9_2_2.zip",
+        sess,
+        event=S3EventIdentity(
+            bucket="wellcomecollection-archivematica-transfer-source",
+            object_key="born-digital-accessions/WT_B_9_2_2.zip",
+            event_name="ObjectCreated:Put",
+            sequencer="manual",
+            event_time=dt.datetime.now(dt.timezone.utc).isoformat(),
+        ),
     )

--- a/lambdas/s3_start_transfer/tests/test_archivematica.py
+++ b/lambdas/s3_start_transfer/tests/test_archivematica.py
@@ -45,6 +45,29 @@ def test_ss_api_get(mock_urlopen, monkeypatch):
     )
 
 
+@patch.object(archivematica.urllib.request, "urlopen")
+def test_am_api_post_json_includes_additional_headers(mock_urlopen, monkeypatch):
+    monkeypatch.setenv("ARCHIVEMATICA_URL", "https://archivematica.example")
+    monkeypatch.setenv("ARCHIVEMATICA_USERNAME", "test-user")
+    monkeypatch.setenv("ARCHIVEMATICA_API_KEY", "test-key")
+    mock_urlopen.return_value.read.return_value = b'{"id": "transfer-uuid"}'
+
+    result = archivematica.am_api_post_json(
+        "/api/v2beta/package",
+        {"name": "test1.zip"},
+        headers={"Idempotency-Key": "event-id"},
+    )
+
+    assert result == {"id": "transfer-uuid"}
+    request = mock_urlopen.call_args.args[0]
+    headers = {key.lower(): value for key, value in request.header_items()}
+    assert headers == {
+        "authorization": "ApiKey test-user:test-key",
+        "content-type": "application/json",
+        "idempotency-key": "event-id",
+    }
+
+
 @patch.object(archivematica, "am_api_post_json")
 def test_start_transfer(mock_am_post):
     transfer_uuid = str(uuid.uuid4())
@@ -54,6 +77,7 @@ def test_start_transfer(mock_am_post):
         name="test1.zip",
         path=b"space1-uuid:/test1.zip",
         processing_config="born-digital",
+        idempotency_key="event-id",
     )
 
     assert actual_transfer_uuid == transfer_uuid
@@ -67,6 +91,7 @@ def test_start_transfer(mock_am_post):
             "processing_config": "born_digital",
             "auto_approve": True,
         },
+        headers={"Idempotency-Key": "event-id"},
     )
 
 
@@ -79,6 +104,7 @@ def test_start_transfer_with_accession(mock_am_post):
         name="test1.zip",
         path=b"space1-uuid:/test1.zip",
         processing_config="b_dig_accessions",
+        idempotency_key="event-id",
         accession_number="1234",
     )
 
@@ -94,6 +120,7 @@ def test_start_transfer_with_accession(mock_am_post):
             "auto_approve": True,
             "accession": "1234",
         },
+        headers={"Idempotency-Key": "event-id"},
     )
 
 
@@ -169,7 +196,10 @@ def test_start_transfer_raises_upon_error(mock_am_post):
 
     with pytest.raises(archivematica.StartTransferException):
         archivematica.start_transfer(
-            "test1.zip", b"space1-uuid:/test1.zip", "born-digital"
+            "test1.zip",
+            b"space1-uuid:/test1.zip",
+            "born-digital",
+            idempotency_key="event-id",
         )
 
 

--- a/lambdas/s3_start_transfer/tests/test_idempotency.py
+++ b/lambdas/s3_start_transfer/tests/test_idempotency.py
@@ -1,0 +1,49 @@
+from idempotency import S3EventIdentity
+
+
+def _event(*, sequencer="0001", version_id=None):
+    return S3EventIdentity(
+        bucket="transfer-bucket",
+        object_key="born-digital/package name.zip",
+        event_name="ObjectCreated:Put",
+        sequencer=sequencer,
+        version_id=version_id,
+        event_time="2026-07-31T08:00:00.000Z",
+    )
+
+
+def test_s3_event_identity_preserves_event_fields():
+    event = S3EventIdentity.from_record(
+        {
+            "eventName": "ObjectCreated:CompleteMultipartUpload",
+            "eventTime": "2026-07-31T08:00:00.000Z",
+            "s3": {
+                "bucket": {"name": "transfer-bucket"},
+                "object": {
+                    "key": "born-digital%2Fpackage+name.zip",
+                    "sequencer": "00ABC123",
+                    "versionId": "version-1",
+                },
+            },
+        }
+    )
+
+    assert event == S3EventIdentity(
+        bucket="transfer-bucket",
+        object_key="born-digital/package name.zip",
+        event_name="ObjectCreated:CompleteMultipartUpload",
+        sequencer="00ABC123",
+        version_id="version-1",
+        event_time="2026-07-31T08:00:00.000Z",
+    )
+
+
+def test_sequencer_and_version_id_are_part_of_event_identity():
+    original = _event()
+
+    assert _event(sequencer="0002").event_id != original.event_id
+    assert _event(version_id="version-1").event_id != original.event_id
+    assert (
+        _event(version_id="version-2").event_id
+        != _event(version_id="version-1").event_id
+    )

--- a/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
@@ -1,16 +1,17 @@
 # -*- encoding: utf-8 -*-
 
 import io
-import re
-import uuid
+import urllib.error
 import zipfile
 from unittest.mock import patch
 
 import boto3
+from botocore.exceptions import ClientError
 from moto import mock_aws
 import pytest
 
 import archivematica
+from idempotency import S3EventIdentity
 import s3_start_transfer
 
 
@@ -39,6 +40,50 @@ def _write_transfer_package(
     return key
 
 
+def _write_package_bytes(
+    sess, *, bucket_name, body, key="born-digital/transfer_package.zip"
+):
+    bucket = sess.resource("s3").Bucket(bucket_name)
+    bucket.create()
+    bucket.put_object(Key=key, Body=body)
+
+    return key
+
+
+def _package_with_metadata(metadata):
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("record.txt", "test transfer")
+        zf.writestr("metadata/metadata.csv", metadata)
+
+    return archive.getvalue()
+
+
+def _event(bucket, key, *, sequencer="0001", version_id=None):
+    return S3EventIdentity(
+        bucket=bucket,
+        object_key=key,
+        event_name="ObjectCreated:Put",
+        sequencer=sequencer,
+        version_id=version_id,
+        event_time="2026-07-31T08:00:00.000Z",
+    )
+
+
+def _log_key(key, result, event):
+    return ".".join([key, result, event.event_time, event.event_id[:12], "log"])
+
+
+def _http_error(status):
+    return urllib.error.HTTPError(
+        "https://archivematica.example/api/v2beta/package",
+        status,
+        "request failed",
+        hdrs=None,
+        fp=None,
+    )
+
+
 def _find_log_object(sess, *, bucket_name):
     s3 = sess.resource("s3")
     bucket = s3.Bucket(bucket_name)
@@ -60,14 +105,15 @@ class TestStartTransfer:
     def test_valid_transfer_is_started(
         self, mock_get_target_path, mock_start_transfer, bucket_name
     ):
-        mock_start_transfer.return_value = str(uuid.uuid4())
+        mock_start_transfer.return_value = "transfer-uuid"
         sess = boto3.Session()
 
         key = _write_transfer_package(
             sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
         )
+        event = _event(bucket_name, key)
 
-        s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=event)
 
         mock_get_target_path.assert_called_with(
             bucket=bucket_name, directory="born-digital", key="transfer_package.zip"
@@ -77,6 +123,7 @@ class TestStartTransfer:
             path=mock_get_target_path.return_value,
             processing_config="born_digital",
             accession_number=None,
+            idempotency_key=event.event_id,
         )
 
     @mock_aws
@@ -85,7 +132,7 @@ class TestStartTransfer:
     def test_valid_accession_transfer_is_started(
         self, mock_get_target_path, mock_start_transfer, bucket_name
     ):
-        mock_start_transfer.return_value = str(uuid.uuid4())
+        mock_start_transfer.return_value = "transfer-uuid"
         sess = boto3.Session()
 
         key = _write_transfer_package(
@@ -94,8 +141,9 @@ class TestStartTransfer:
             filename="valid_accession_package.zip",
             key="born-digital-accessions/LEMON_1234.zip",
         )
+        event = _event(bucket_name, key)
 
-        s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=event)
 
         mock_get_target_path.assert_called_with(
             bucket=bucket_name,
@@ -107,6 +155,7 @@ class TestStartTransfer:
             path=mock_get_target_path.return_value,
             processing_config="b_dig_accessions",
             accession_number="1234",
+            idempotency_key=event.event_id,
         )
 
     @mock_aws
@@ -115,22 +164,19 @@ class TestStartTransfer:
     def test_valid_transfer_creates_success_log(
         self, mock_get_target_path, mock_start_transfer, bucket_name
     ):
-        mock_start_transfer.return_value = str(uuid.uuid4())
+        mock_start_transfer.return_value = "transfer-uuid"
         sess = boto3.Session()
 
         key = _write_transfer_package(
             sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
         )
+        event = _event(bucket_name, key)
 
-        s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=event)
 
         log_object = _find_log_object(sess, bucket_name=bucket_name)
 
-        # Example: born-digital/transfer_package.zip.success.2019-12-13_14-46-09.log
-        assert re.match(
-            r"^born-digital/transfer_package\.zip\.success\.\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.log$",
-            log_object.key,
-        )
+        assert log_object.key == _log_key(key, "success", event)
 
         log_text = log_object.get()["Body"].read()
         assert b"All checks complete!\nStarted successful transfer!" in log_text
@@ -141,16 +187,14 @@ class TestStartTransfer:
         key = _write_transfer_package(
             sess, bucket_name=bucket_name, filename="no_metadata_csv.zip"
         )
+        event = _event(bucket_name, key)
 
-        s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=event)
+        s3_start_transfer.run_transfer(sess, event=event)
 
         log_object = _find_log_object(sess, bucket_name=bucket_name)
 
-        # Example: born-digital/transfer_package.zip.failed.2019-12-13_14-46-09.log
-        assert re.match(
-            r"^born-digital/transfer_package\.zip\.failed\.\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.log$",
-            log_object.key,
-        )
+        assert log_object.key == _log_key(key, "failed", event)
 
         log_text = log_object.get()["Body"].read()
         assert b"== Check 1: verify_has_a_metadata_csv ==\nCheck failed:" in log_text
@@ -175,31 +219,65 @@ class TestStartTransfer:
             sess, bucket_name=bucket_name, filename=filename, key=key
         )
 
-        s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+        s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
         mock_get_target_path.assert_not_called()
         mock_start_transfer.assert_not_called()
 
     @mock_aws
-    def test_error_while_calling_archivematica_writes_failure_log(self, bucket_name):
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
+    @pytest.mark.parametrize(
+        "body, expected_error",
+        [
+            (b"not a ZIP archive", b"File is not a zip file"),
+            (
+                _package_with_metadata(b"filename,dc.identifier\nobjects/,\xff\n"),
+                b"codec can't decode byte 0xff",
+            ),
+        ],
+    )
+    def test_malformed_package_writes_failed_log_without_starting_transfer(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+        body,
+        expected_error,
+    ):
+        sess = boto3.Session()
+        key = _write_package_bytes(sess, bucket_name=bucket_name, body=body)
+        event = _event(bucket_name, key)
+
+        s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_get_target_path.assert_not_called()
+        mock_start_transfer.assert_not_called()
+
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
+        assert log_object.key == _log_key(key, "failed", event)
+
+        log_text = log_object.get()["Body"].read()
+        assert b"Unable to read transfer package:" in log_text
+        assert expected_error in log_text
+
+    @mock_aws
+    def test_missing_storage_service_path_writes_failure_log(self, bucket_name):
         sess = boto3.Session()
         key = _write_transfer_package(
             sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
         )
+        event = _event(bucket_name, key)
 
         def boom(*args, **kwargs):
-            raise ValueError("BOOM!")
+            raise archivematica.StoragePathException("BOOM!")
 
         with patch.object(archivematica, "get_target_path", boom):
-            s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+            s3_start_transfer.run_transfer(sess, event=event)
 
         log_object = _find_log_object(sess, bucket_name=bucket_name)
 
-        # Example: born-digital/transfer_package.zip.failed.2019-12-13_14-46-09.log
-        assert re.match(
-            r"^born-digital/transfer_package\.zip\.failed\.\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.log$",
-            log_object.key,
-        )
+        assert log_object.key == _log_key(key, "failed", event)
 
         log_text = log_object.get()["Body"].read()
         assert b"Error starting transfer: BOOM!" in log_text
@@ -207,10 +285,236 @@ class TestStartTransfer:
     @mock_aws
     @patch.object(archivematica, "start_transfer")
     @patch.object(archivematica, "get_target_path")
+    def test_unknown_transfer_source_writes_failure_log(
+        self, mock_get_target_path, mock_start_transfer, bucket_name
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess,
+            bucket_name=bucket_name,
+            filename="valid_transfer_package.zip",
+            key="unknown/transfer_package.zip",
+        )
+        event = _event(bucket_name, key)
+
+        s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_get_target_path.assert_not_called()
+        mock_start_transfer.assert_not_called()
+
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
+        assert log_object.key == _log_key(key, "failed", event)
+
+        log_text = log_object.get()["Body"].read()
+        assert b"Unable to determine processing config" in log_text
+
+    @mock_aws
+    @patch.object(archivematica, "start_transfer", return_value="transfer-uuid")
+    @patch.object(archivematica, "get_target_path")
+    def test_duplicate_delivery_reuses_idempotency_key_and_success_log(
+        self, mock_get_target_path, mock_start_transfer, bucket_name
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+
+        s3_start_transfer.run_transfer(sess, event=event)
+        s3_start_transfer.run_transfer(sess, event=event)
+
+        assert mock_start_transfer.call_count == 2
+        assert [
+            call.kwargs["idempotency_key"]
+            for call in mock_start_transfer.call_args_list
+        ] == [event.event_id, event.event_id]
+
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
+        assert log_object.key == _log_key(key, "success", event)
+
+        tags = {
+            tag["Key"]: tag["Value"]
+            for tag in sess.client("s3").get_object_tagging(
+                Bucket=bucket_name, Key=key
+            )["TagSet"]
+        }
+        assert tags["Archivematica-TransferId"] == "transfer-uuid"
+        assert tags["Archivematica-S3EventTime"] == event.event_time
+
+    @mock_aws
+    @patch.object(
+        archivematica, "start_transfer", side_effect=["transfer-1", "transfer-2"]
+    )
+    @patch.object(archivematica, "get_target_path")
+    def test_new_sequencer_starts_a_new_transfer(
+        self, mock_get_target_path, mock_start_transfer, bucket_name
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+
+        first_event = _event(bucket_name, key, sequencer="0001")
+        second_event = _event(bucket_name, key, sequencer="0002")
+
+        s3_start_transfer.run_transfer(sess, event=first_event)
+        s3_start_transfer.run_transfer(sess, event=second_event)
+
+        assert mock_start_transfer.call_count == 2
+        assert [
+            call.kwargs["idempotency_key"]
+            for call in mock_start_transfer.call_args_list
+        ] == [first_event.event_id, second_event.event_id]
+        assert first_event.event_id != second_event.event_id
+
+    @mock_aws
+    @patch.object(archivematica, "get_target_path")
+    def test_uncertain_submission_is_retried_with_same_idempotency_key(
+        self, mock_get_target_path, bucket_name
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+
+        with patch.object(
+            archivematica,
+            "start_transfer",
+            side_effect=[TimeoutError("response lost"), "transfer-uuid"],
+        ) as mock_start_transfer:
+            with pytest.raises(TimeoutError, match="response lost"):
+                s3_start_transfer.run_transfer(sess, event=event)
+            s3_start_transfer.run_transfer(sess, event=event)
+
+        assert [
+            call.kwargs["idempotency_key"]
+            for call in mock_start_transfer.call_args_list
+        ] == [event.event_id, event.event_id]
+        _find_log_object(sess, bucket_name=bucket_name)
+
+    @mock_aws
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(
+                archivematica.StartTransferException("invalid processing config"),
+                id="error-response",
+            ),
+            pytest.param(_http_error(400), id="bad-request"),
+            pytest.param(_http_error(422), id="idempotency-conflict"),
+        ],
+    )
+    def test_permanent_submission_error_writes_failure_log(
+        self, mock_get_target_path, mock_start_transfer, bucket_name, error
+    ):
+        mock_start_transfer.side_effect = error
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+
+        s3_start_transfer.run_transfer(sess, event=event)
+
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
+        assert log_object.key == _log_key(key, "failed", event)
+        assert b"Error starting transfer:" in log_object.get()["Body"].read()
+
+    @mock_aws
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
+    @pytest.mark.parametrize("status", [408, 409, 425, 429, 500])
+    def test_retryable_http_submission_error_fails_invocation(
+        self, mock_get_target_path, mock_start_transfer, bucket_name, status
+    ):
+        error = _http_error(status)
+        mock_start_transfer.side_effect = error
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+
+        with pytest.raises(urllib.error.HTTPError) as raised:
+            s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
+
+        assert raised.value is error
+
+    @mock_aws
+    @patch.object(archivematica, "start_transfer", return_value="transfer-uuid")
+    @patch.object(archivematica, "get_target_path")
+    @pytest.mark.parametrize("failure_target", ["package", "success_log"])
+    def test_s3_feedback_failure_is_safe_to_retry(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+        failure_target,
+    ):
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+        event = _event(bucket_name, key)
+        s3_client = sess.client("s3")
+        success_log_key = _log_key(key, "success", event)
+        failed_key = key if failure_target == "package" else success_log_key
+        put_object_tagging = s3_client.put_object_tagging
+        tagging_error = ClientError(
+            {"Error": {"Code": "InternalError", "Message": "unavailable"}},
+            "PutObjectTagging",
+        )
+        failed = False
+
+        def fail_once(**kwargs):
+            nonlocal failed
+            if kwargs["Key"] == failed_key and not failed:
+                failed = True
+                raise tagging_error
+            return put_object_tagging(**kwargs)
+
+        with (
+            patch.object(sess, "client", return_value=s3_client),
+            patch.object(s3_client, "put_object_tagging", side_effect=fail_once),
+        ):
+            with pytest.raises(ClientError, match="InternalError"):
+                s3_start_transfer.run_transfer(sess, event=event)
+            s3_start_transfer.run_transfer(sess, event=event)
+
+        assert mock_start_transfer.call_count == 2
+        assert [
+            call.kwargs["idempotency_key"]
+            for call in mock_start_transfer.call_args_list
+        ] == [event.event_id, event.event_id]
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
+        assert log_object.key == success_log_key
+
+    @mock_aws
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
+    def test_storage_service_transport_error_is_retryable(
+        self, mock_get_target_path, mock_start_transfer, bucket_name
+    ):
+        mock_get_target_path.side_effect = OSError("service unavailable")
+        sess = boto3.Session()
+        key = _write_transfer_package(
+            sess, bucket_name=bucket_name, filename="valid_transfer_package.zip"
+        )
+
+        with pytest.raises(OSError, match="service unavailable"):
+            s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
+
+        mock_start_transfer.assert_not_called()
+
+    @mock_aws
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
     def test_deflate64_accession_uses_filename_as_accession_number(
         self, mock_get_target_path, mock_start_transfer, bucket_name
     ):
-        mock_start_transfer.return_value = str(uuid.uuid4())
+        mock_start_transfer.return_value = "transfer-uuid"
         sess = boto3.Session()
         key = _write_transfer_package(
             sess,
@@ -218,19 +522,21 @@ class TestStartTransfer:
             filename="valid_transfer_package.zip",
             key="born-digital-accessions/WT_B_9_2_2.zip",
         )
+        event = _event(bucket_name, key)
 
         with patch.object(
             s3_start_transfer,
             "verify_s3_package",
             side_effect=NotImplementedError("That compression method is not supported"),
         ):
-            s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+            s3_start_transfer.run_transfer(sess, event=event)
 
         mock_start_transfer.assert_called_once_with(
             name="WT_B_9_2_2.zip",
             path=mock_get_target_path.return_value,
             processing_config="b_dig_accessions",
             accession_number="WT_B_9_2_2",
+            idempotency_key=event.event_id,
         )
 
     @mock_aws
@@ -257,7 +563,7 @@ class TestStartTransfer:
             side_effect=NotImplementedError(error),
         ):
             with patch.object(archivematica, "start_transfer") as mock_start_transfer:
-                s3_start_transfer.run_transfer(sess, bucket=bucket_name, key=key)
+                s3_start_transfer.run_transfer(sess, event=_event(bucket_name, key))
 
         mock_start_transfer.assert_not_called()
 
@@ -283,41 +589,78 @@ def test_main_runs_all_events(bucket_name):
     event = {
         "Records": [
             {
+                "eventName": "ObjectCreated:Put",
+                "eventTime": "2026-07-31T08:00:00.000Z",
                 "s3": {
                     "bucket": {"name": bucket_name},
-                    "object": {"key": "born-digital%2Ftransfer_package1.zip"},
-                }
+                    "object": {
+                        "key": "born-digital%2Ftransfer_package1.zip",
+                        "sequencer": "0001",
+                    },
+                },
             },
             {
+                "eventName": "ObjectCreated:CompleteMultipartUpload",
+                "eventTime": "2026-07-31T08:01:00.000Z",
                 "s3": {
                     "bucket": {"name": bucket_name},
-                    "object": {"key": "born-digital%2Ftransfer_package2.zip"},
-                }
+                    "object": {
+                        "key": "born-digital%2Ftransfer_package2.zip",
+                        "sequencer": "0002",
+                    },
+                },
             },
         ]
     }
 
     with patch.object(archivematica, "get_target_path"):
         with patch.object(archivematica, "start_transfer") as mock_start_transfer:
-            mock_start_transfer.return_value = str(uuid.uuid4())
+            mock_start_transfer.side_effect = ["transfer-1", "transfer-2"]
             s3_start_transfer.main(event=event)
 
             assert mock_start_transfer.call_count == 2
 
 
-@mock_aws
-def test_main_continues_after_an_event_raises(bucket_name):
+def test_main_reports_infrastructure_failure_after_processing_all_records():
+    first_error = ClientError(
+        {"Error": {"Code": "InternalServerError", "Message": "unavailable"}},
+        "PutObjectTagging",
+    )
+    second_error = TimeoutError("Archivematica unavailable")
     event = {
         "Records": [
-            {"s3": {"bucket": {"name": bucket_name}, "object": {"key": "one"}}},
-            {"s3": {"bucket": {"name": bucket_name}, "object": {"key": "two"}}},
+            {
+                "eventName": "ObjectCreated:Put",
+                "eventTime": "2026-07-31T08:00:00.000Z",
+                "s3": {
+                    "bucket": {"name": "transfer-bucket"},
+                    "object": {
+                        "key": "born-digital%2Fpackage1.zip",
+                        "sequencer": "0001",
+                    },
+                },
+            },
+            {
+                "eventName": "ObjectCreated:Put",
+                "eventTime": "2026-07-31T08:01:00.000Z",
+                "s3": {
+                    "bucket": {"name": "transfer-bucket"},
+                    "object": {
+                        "key": "born-digital%2Fpackage2.zip",
+                        "sequencer": "0002",
+                    },
+                },
+            },
         ]
     }
 
     with patch.object(
-        s3_start_transfer, "run_transfer", side_effect=[ValueError("BOOM!"), None]
+        s3_start_transfer,
+        "run_transfer",
+        side_effect=[first_error, second_error],
     ) as mock_run_transfer:
-        s3_start_transfer.main(event=event)
+        with pytest.raises(ClientError, match="InternalServerError"):
+            s3_start_transfer.main(event=event)
 
     assert mock_run_transfer.call_count == 2
 


### PR DESCRIPTION
## What does this change?

Adds stable `Idempotency-Key` headers to Archivematica transfer requests so duplicate S3 deliveries and retries can reuse the original Transfer UUID.

Submission and S3 feedback failures now fail the invocation for retry. Invalid packages and permanent configuration failures remain terminal.

## How to test

Run:

```console
cd lambdas/s3_start_transfer
coverage run -m pytest tests
```

## How can we measure success?

- Duplicate deliveries and retries create one Transfer.
- Genuine re-uploads create a new Transfer.
- Retried attempts overwrite the same S3 feedback.

## Have we considered potential risks?

- The currently pinned Archivematica images ignore idempotency keys. Until supported Dashboard and MCPServer images are deployed (https://github.com/wellcomecollection/archivematica-infrastructure/pull/178), retries may still create duplicate Transfers.
- Idempotency keys are retained for 90 days; replaying older events may create another Transfer.

Fixes #182.