### PR TITLE
Print image tags in CI

### DIFF
--- a/.buildkite/scripts/publish_docker_image.sh
+++ b/.buildkite/scripts/publish_docker_image.sh
@@ -7,7 +7,7 @@ ACCOUNT_ID="299497370133"
 SERVICE_ID="$1"
 
 ROOT=$(git rev-parse --show-toplevel)
-CURRENT_COMMIT=$(git log -1 --pretty=format:"%H" archivematica-apps/$SERVICE_ID)
+SOURCE_COMMIT=$(git log -1 --pretty=format:"%H" archivematica-apps/$SERVICE_ID)
 
 ROOT=$(git rev-parse --show-toplevel)
 
@@ -17,12 +17,15 @@ aws ecr get-login-password \
     --username AWS \
     --password-stdin 299497370133.dkr.ecr.eu-west-1.amazonaws.com
 
-LOCAL_IMAGE_TAG="$SERVICE_ID:$CURRENT_COMMIT"
+LOCAL_IMAGE_TAG="$SERVICE_ID:$SOURCE_COMMIT"
 REMOTE_IMAGE_TAG="$ACCOUNT_ID.dkr.ecr.eu-west-1.amazonaws.com/weco/$LOCAL_IMAGE_TAG"
 
 echo "*** Pushing $LOCAL_IMAGE_TAG to $REMOTE_IMAGE_TAG"
+echo "*** Image provenance"
+echo "Source commit: $SOURCE_COMMIT"
+echo "Image tag: $SOURCE_COMMIT"
 docker tag "$LOCAL_IMAGE_TAG" "$REMOTE_IMAGE_TAG"
 docker push "$REMOTE_IMAGE_TAG"
 docker rmi "$REMOTE_IMAGE_TAG"
 
-buildkite-agent annotate --append --style info "Published image $LOCAL_IMAGE_TAG<br/>"
+buildkite-agent annotate --append --style info "Published image $LOCAL_IMAGE_TAG<br/>Source commit: $SOURCE_COMMIT<br/>"

--- a/archivematica-apps/archivematica-storage-service/README.md
+++ b/archivematica-apps/archivematica-storage-service/README.md
@@ -13,7 +13,7 @@ It's different from the Wellcome storage service.
 
 Run the `build_and_publish_image.sh` script.
 
-You can get a newer version of the code from Artefactual upstream by changing the `ARCHIVEMATICA_TAG` variable.
+You can get a newer version of the code from Artefactual upstream by changing the `UPSTREAM_COMMIT` variable in `build_and_publish_image.sh`.
 
 ## How the overlay works
 

--- a/archivematica-apps/archivematica-storage-service/build_and_publish_image.sh
+++ b/archivematica-apps/archivematica-storage-service/build_and_publish_image.sh
@@ -5,10 +5,10 @@ set -o nounset
 
 # This untagged commit was in qa/0.x when the overlay was updated.
 # It is the Storage Service revision used by Archivematica 306db677.
-ARCHIVEMATICA_TAG=e1996eb9c7ce7488a4ce31175bb25efe125e58bd
+UPSTREAM_COMMIT=e1996eb9c7ce7488a4ce31175bb25efe125e58bd
 
 ROOT=$(git rev-parse --show-toplevel)
-CURRENT_COMMIT=$(git log -1 --pretty=format:"%H" "$ROOT"/archivematica-apps/archivematica-storage-service)
+OVERLAY_COMMIT=$(git log -1 --pretty=format:"%H" "$ROOT"/archivematica-apps/archivematica-storage-service)
 
 aws ecr get-login-password \
 | docker login \
@@ -21,8 +21,8 @@ pushd $(mktemp -d)
   git clone https://github.com/artefactual/archivematica-storage-service.git
   cd archivematica-storage-service
 
-  echo "*** Checking out tag $ARCHIVEMATICA_TAG"
-  git checkout "$ARCHIVEMATICA_TAG"
+  echo "*** Checking out upstream commit $UPSTREAM_COMMIT"
+  git checkout "$UPSTREAM_COMMIT"
 
   echo "*** Applying overlay files to repository"
   python3 "$ROOT/archivematica-apps/archivematica-storage-service/copy_overlay_files.py"
@@ -33,9 +33,16 @@ pushd $(mktemp -d)
 
   echo "*** Pushing to ECR"
 
-  ECR_IMAGE_TAG="299497370133.dkr.ecr.eu-west-1.amazonaws.com/weco/archivematica-storage-service:$ARCHIVEMATICA_TAG-$CURRENT_COMMIT"
+  IMAGE_TAG="$UPSTREAM_COMMIT-$OVERLAY_COMMIT"
+  ECR_IMAGE_TAG="299497370133.dkr.ecr.eu-west-1.amazonaws.com/weco/archivematica-storage-service:$IMAGE_TAG"
   docker tag "archivematica-storage-service" "$ECR_IMAGE_TAG"
+
+  echo "*** Image provenance"
+  echo "Upstream Storage Service commit: $UPSTREAM_COMMIT"
+  echo "Wellcome overlay commit: $OVERLAY_COMMIT"
+  echo "Image tag: $IMAGE_TAG"
+
   docker push "$ECR_IMAGE_TAG"
 
-  buildkite-agent annotate --append --style info "Published image archivematica-storage-service:$ARCHIVEMATICA_TAG-$CURRENT_COMMIT<br/>"
+  buildkite-agent annotate --append --style info "Published image archivematica-storage-service:$IMAGE_TAG<br/>Upstream Storage Service commit: $UPSTREAM_COMMIT<br/>Wellcome overlay commit: $OVERLAY_COMMIT<br/>"
 popd

--- a/archivematica-apps/archivematica/README.md
+++ b/archivematica-apps/archivematica/README.md
@@ -12,7 +12,7 @@ We only diverge slightly from Archivematica upstream, so rather than maintaining
 
 Run `build_and_publish_image.sh` with `dashboard`, `mcp-client`, or `mcp-server` as its argument.
 
-You can get a newer version of the code from Artefactual upstream by changing the `ARCHIVEMATICA_TAG` variable.
+You can get a newer version of the code from Artefactual upstream by changing the `UPSTREAM_COMMIT` variable in `build_and_publish_image.sh`.
 
 ## How the overlay works
 

--- a/archivematica-apps/archivematica/build_and_publish_image.sh
+++ b/archivematica-apps/archivematica/build_and_publish_image.sh
@@ -11,11 +11,11 @@ fi
 
 # This untagged commit was the tip of qa/1.x when the overlay was updated.
 # Pin the SHA so later changes to the branch do not alter this build.
-ARCHIVEMATICA_TAG=306db6773216e607cf5687f84fb0be353949ddb7
+UPSTREAM_COMMIT=306db6773216e607cf5687f84fb0be353949ddb7
 SERVICE="$1"
 
 ROOT=$(git rev-parse --show-toplevel)
-CURRENT_COMMIT=$(git log -1 --pretty=format:"%H" $ROOT/archivematica-apps/archivematica)
+OVERLAY_COMMIT=$(git log -1 --pretty=format:"%H" "$ROOT"/archivematica-apps/archivematica)
 
 aws ecr get-login-password \
 | docker login \
@@ -28,8 +28,8 @@ pushd $(mktemp -d)
   git clone https://github.com/artefactual/archivematica.git
   cd archivematica
 
-  echo "*** Checking out tag $ARCHIVEMATICA_TAG"
-  git checkout "$ARCHIVEMATICA_TAG"
+  echo "*** Checking out upstream commit $UPSTREAM_COMMIT"
+  git checkout "$UPSTREAM_COMMIT"
 
   echo "*** Applying overlay files to repository"
   python3 "$ROOT/archivematica-apps/archivematica/copy_overlay_files.py"
@@ -42,10 +42,16 @@ pushd $(mktemp -d)
 
   echo "*** Pushing to ECR"
 
-  ECR_IMAGE_TAG="299497370133.dkr.ecr.eu-west-1.amazonaws.com/weco/archivematica-$SERVICE:$ARCHIVEMATICA_TAG-$CURRENT_COMMIT"
+  IMAGE_TAG="$UPSTREAM_COMMIT-$OVERLAY_COMMIT"
+  ECR_IMAGE_TAG="299497370133.dkr.ecr.eu-west-1.amazonaws.com/weco/archivematica-$SERVICE:$IMAGE_TAG"
   docker tag "am-archivematica-$SERVICE" "$ECR_IMAGE_TAG"
+
+  echo "*** Image provenance"
+  echo "Upstream Archivematica commit: $UPSTREAM_COMMIT"
+  echo "Wellcome overlay commit: $OVERLAY_COMMIT"
+  echo "Image tag: $IMAGE_TAG"
 
   docker push "$ECR_IMAGE_TAG"
 
-  buildkite-agent annotate --append --style info "Published image archivematica-$SERVICE:$ARCHIVEMATICA_TAG-$CURRENT_COMMIT<br/>"
+  buildkite-agent annotate --append --style info "Published image archivematica-$SERVICE:$IMAGE_TAG<br/>Upstream Archivematica commit: $UPSTREAM_COMMIT<br/>Wellcome overlay commit: $OVERLAY_COMMIT<br/>"
 popd


### PR DESCRIPTION
## What does this change?

Makes Docker image tags clearer in CI by showing the upstream and Wellcome commit SHAs separately.

## How to test

Run the Buildkite pipeline and check the image provenance output and annotation.

## How can we measure success?

Image tags can be understood without inspecting the build scripts.

## Have we considered potential risks?

Low risk: image tag construction and publishing behaviour are unchanged.
