### PR TITLE
Bump gearmand from 1.1.18 to 2.0.0

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -32,7 +32,7 @@ module "gearman_service" {
   name      = "gearman"
   namespace = var.namespace
 
-  container_image = "artefactual/gearmand:1.1.18-alpine"
+  container_image = "artefactual/gearmand:2.0.0-alpine"
 
   command = [
     "--queue-type=redis",


### PR DESCRIPTION
See https://github.com/wellcomecollection/archivematica-infrastructure/issues/181 for more details.