### PR TITLE
Validate rights CSV transfer metadata

### DIFF
--- a/docs/storing-born-digital-files/creating-a-transfer-package.md
+++ b/docs/storing-born-digital-files/creating-a-transfer-package.md
@@ -29,7 +29,20 @@ We use two metadata files in our transfer packages:
     ```
 
     In both cases, the CSV only ever has `objects/` as the filename.
-* `rights.csv`, [which contains the rights information](https://app.gitbook.com/o/-LumfFcEMKx4gYXKAZTQ/s/ZZCA7ig38ZIKLAnLhUp8/) \[[https://github.com/wellcomecollection/archivematica-infrastructure/issues/113](https://github.com/wellcomecollection/archivematica-infrastructure/issues/113)]
+* `rights.csv`, which is optional and describes the rights attached to individual files or directories.
+
+    The file must have a header row and at least one row of rights information. Every row must have a `file` and `basis` value. The `file` is the Archivematica path to the file or directory, so it must begin with `objects/`. The supported bases are `copyright`, `donor`, `license`, `other`, `policy`, and `statute`.
+
+    For a copyright basis, `status` and `jurisdiction` are also required. For a statute basis, `citation` and `jurisdiction` are required. To describe access, use `grant_act` together with `grant_restriction`, whose value must be `allow`, `conditional`, or `disallow`.
+
+    The optional columns are `status`, `determination_date`, `start_date`, `end_date`, `jurisdiction`, `terms`, `citation`, `note`, `grant_act`, `grant_restriction`, `grant_start_date`, `grant_end_date`, `grant_note`, `doc_id_type`, `doc_id_value`, and `doc_id_role`. No other columns are accepted.
+
+    For example, this applies a copyright statement to a file and disallows dissemination:
+
+    ```csv
+    file,basis,status,jurisdiction,grant_act,grant_restriction
+    objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
+    ```
 
 ## Compressing the package
 

--- a/docs/storing-born-digital-files/creating-a-transfer-package.md
+++ b/docs/storing-born-digital-files/creating-a-transfer-package.md
@@ -29,11 +29,11 @@ We use two metadata files in our transfer packages:
     ```
 
     In both cases, the CSV only ever has `objects/` as the filename.
-* `rights.csv`, which is optional and describes the rights attached to individual files or directories.
+* `rights.csv`, which is optional and describes the rights attached to individual files.
 
-    The file must have a header row and at least one row of rights information. Every row must have a `file` and `basis` value. The `file` is the Archivematica path to the file or directory, so it must begin with `objects/`. The supported bases are `copyright`, `donor`, `license`, `other`, `policy`, and `statute`.
+    The file must have a header row and at least one row of rights information. Every row must have a `file` and `basis` value. The `file` must identify a file in the transfer package and use its Archivematica path, beginning with `objects/`. The supported bases are `copyright`, `donor`, `license`, `other`, `policy`, and `statute`.
 
-    For a copyright basis, `status` and `jurisdiction` are also required. For a statute basis, `citation` and `jurisdiction` are required. To describe access, use `grant_act` together with `grant_restriction`, whose value must be `allow`, `conditional`, or `disallow`.
+    For a copyright basis, `status` and `jurisdiction` are also required. For a statute basis, `citation` and `jurisdiction` are required. If any grant information is supplied, both `grant_act` and `grant_restriction` must have values. The restriction must be `allow`, `conditional`, or `disallow`.
 
     The optional columns are `status`, `determination_date`, `start_date`, `end_date`, `jurisdiction`, `terms`, `citation`, `note`, `grant_act`, `grant_restriction`, `grant_start_date`, `grant_end_date`, `grant_note`, `doc_id_type`, `doc_id_value`, and `doc_id_role`. No other columns are accepted.
 

--- a/docs/storing-born-digital-files/creating-a-transfer-package.md
+++ b/docs/storing-born-digital-files/creating-a-transfer-package.md
@@ -4,13 +4,16 @@ A **transfer package** is a zip file containing the born-digital files you want 
 
 The files can be in any structure, including folders and subfolders.
 
-![An example transfer package. There's a folder called "transfer\_package", which contains three images and a folder called "metadata". The metadata folder contains a single file, metadata.csv.](../howto/transfer_package.png)
+![An example transfer package.
+There's a folder called "transfer\_package", which contains three images and a folder called "metadata".
+The metadata folder contains a single file, metadata.csv.](../howto/transfer_package.png)
 
 The metadata files **must** be stored in a top-level folder called `metadata`.
 
 ## Metadata files
 
-We use two metadata files in our transfer packages:
+We use two metadata files in our transfer packages.
+Both files must use UTF-8 encoding:
 
 *   `metadata.csv`, which contains the identifier.
 
@@ -29,13 +32,20 @@ We use two metadata files in our transfer packages:
     ```
 
     In both cases, the CSV only ever has `objects/` as the filename.
-* `rights.csv`, which is optional and describes the rights attached to individual files.
+*   `rights.csv`, which is optional and describes the rights attached to individual files.
 
-    The file must have a header row and at least one row of rights information. Every row must have a `file` and `basis` value. The `file` must identify a file in the transfer package and use its Archivematica path, beginning with `objects/`. The supported bases are `copyright`, `donor`, `license`, `other`, `policy`, and `statute`.
+    The file must have a header row and at least one row of rights information.
+    Every row must have a `file` and `basis` value.
+    The `file` must identify a file in the transfer package and use its Archivematica path, beginning with `objects/`.
+    The supported bases are `copyright`, `donor`, `license`, `other`, `policy`, and `statute`.
 
-    For a copyright basis, `status` and `jurisdiction` are also required. For a statute basis, `citation` and `jurisdiction` are required. If any grant information is supplied, both `grant_act` and `grant_restriction` must have values. The restriction must be `allow`, `conditional`, or `disallow`.
+    For a copyright basis, `status` and `jurisdiction` are also required.
+    For a statute basis, `citation` and `jurisdiction` are required.
+    If any grant information is supplied, both `grant_act` and `grant_restriction` must have values.
+    The restriction must be `allow`, `conditional`, or `disallow`.
 
-    The optional columns are `status`, `determination_date`, `start_date`, `end_date`, `jurisdiction`, `terms`, `citation`, `note`, `grant_act`, `grant_restriction`, `grant_start_date`, `grant_end_date`, `grant_note`, `doc_id_type`, `doc_id_value`, and `doc_id_role`. No other columns are accepted.
+    The optional columns are `status`, `determination_date`, `start_date`, `end_date`, `jurisdiction`, `terms`, `citation`, `note`, `grant_act`, `grant_restriction`, `grant_start_date`, `grant_end_date`, `grant_note`, `doc_id_type`, `doc_id_value`, and `doc_id_role`.
+    No other columns are accepted.
 
     For example, this applies a copyright statement to a file and disallows dissemination:
 

--- a/docs/storing-born-digital-files/creating-a-transfer-package.md
+++ b/docs/storing-born-digital-files/creating-a-transfer-package.md
@@ -34,15 +34,25 @@ Both files must use UTF-8 encoding:
     In both cases, the CSV only ever has `objects/` as the filename.
 *   `rights.csv`, which is optional and describes the rights attached to individual files.
 
+    The file must use UTF-8 without a byte-order mark (BOM).
     The file must have a header row and at least one row of rights information.
     Every row must have a `file` and `basis` value.
     The `file` must identify a file in the transfer package and use its Archivematica path, beginning with `objects/`.
     The supported bases are `copyright`, `donor`, `license`, `other`, `policy`, and `statute`.
 
     For a copyright basis, `status` and `jurisdiction` are also required.
+    Copyright rows may also have `determination_date`, `start_date`, `end_date`, and `note` values.
+    A copyright `end_date` must be a date or empty and cannot be `open`.
+    For a donor, other, or policy basis, rows may have `start_date`, `end_date`, and `note` values.
+    For a license basis, rows may have `start_date`, `end_date`, `terms`, and `note` values.
     For a statute basis, `citation` and `jurisdiction` are required.
+    Statute rows may also have `determination_date`, `start_date`, `end_date`, and `note` values.
+    Basis-specific fields not listed for the selected basis must be empty because Archivematica would discard them.
     If any grant information is supplied, both `grant_act` and `grant_restriction` must have values.
     The restriction must be `allow`, `conditional`, or `disallow`.
+    If any documentation identifier information is supplied, both `doc_id_type` and `doc_id_value` must have values.
+    The `doc_id_role` value is optional.
+    Each combination of `file`, `basis`, and `grant_act` may appear only once after surrounding whitespace and letter case are normalized.
 
     The optional columns are `status`, `determination_date`, `start_date`, `end_date`, `jurisdiction`, `terms`, `citation`, `note`, `grant_act`, `grant_restriction`, `grant_start_date`, `grant_end_date`, `grant_note`, `doc_id_type`, `doc_id_value`, and `doc_id_role`.
     No other columns are accepted.

--- a/docs/storing-born-digital-files/creating-a-transfer-package.md
+++ b/docs/storing-born-digital-files/creating-a-transfer-package.md
@@ -42,7 +42,7 @@ Both files must use UTF-8 encoding:
 
     For a copyright basis, `status` and `jurisdiction` are also required.
     Copyright rows may also have `determination_date`, `start_date`, `end_date`, and `note` values.
-    A copyright `end_date` must be a date or empty and cannot be `open`.
+    A copyright `end_date` cannot be `open`; leave the value empty for no end date.
     For a donor, other, or policy basis, rows may have `start_date`, `end_date`, and `note` values.
     For a license basis, rows may have `start_date`, `end_date`, `terms`, and `note` values.
     For a statute basis, `citation` and `jurisdiction` are required.
@@ -52,7 +52,8 @@ Both files must use UTF-8 encoding:
     The restriction must be `allow`, `conditional`, or `disallow`.
     If any documentation identifier information is supplied, both `doc_id_type` and `doc_id_value` must have values.
     The `doc_id_role` value is optional.
-    Each combination of `file`, `basis`, and `grant_act` may appear only once after surrounding whitespace and letter case are normalized.
+    Each combination of `file`, `basis`, and `grant_act` may appear only once.
+    Surrounding whitespace is ignored for all three values, while letter case is ignored for `basis` and `grant_act`; file paths remain case-sensitive.
 
     The optional columns are `status`, `determination_date`, `start_date`, `end_date`, `jurisdiction`, `terms`, `citation`, `note`, `grant_act`, `grant_restriction`, `grant_start_date`, `grant_end_date`, `grant_note`, `doc_id_type`, `doc_id_value`, and `doc_id_role`.
     No other columns are accepted.

--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -54,9 +54,12 @@ The upstream reference for this contract is Archivematica's `qa/1.x` branch:
 *   Archivematica's [`RightsValidator`](https://github.com/artefactual/archivematica/blob/qa/1.x/src/archivematica/dashboard/components/api/validators.py) defines the intended CSV schema, including allowed columns, basis-specific fields, documentation identifiers, and grant restrictions.
 *   Archivematica's [`rights_from_csv.py`](https://github.com/artefactual/archivematica/blob/qa/1.x/src/archivematica/MCPClient/clientScripts/rights_from_csv.py) is the actual importer and therefore determines which values are persisted or cause an import failure.
 
-These source links intentionally follow `qa/1.x`, while [the image build](../../archivematica-apps/archivematica/build_and_publish_image.sh) pins a commit selected from that branch for a reproducible image.
-The final upstream and Wellcome overlay commit hashes can vary as images are updated or environments are rolled independently.
-To identify the exact revisions selected for deployment, inspect the `ecr_image_tags` variables in the [staging locals](../../terraform/stack_staging/locals.tf) or [production locals](../../terraform/stack_prod/locals.tf), where each Archivematica image tag contains the upstream commit followed by the overlay commit.
+These source links intentionally follow `qa/1.x`, while [the current image build](../../archivematica-apps/archivematica/build_and_publish_image.sh) pins a commit selected from that branch for reproducible future images.
+An environment may still run an image produced by an earlier version of the build script.
+The final upstream and Wellcome overlay revisions can vary as images are updated or environments are rolled independently.
+To identify the exact revisions selected for deployment, inspect the `ecr_image_tags` variables in the [staging locals](../../terraform/stack_staging/locals.tf) or [production locals](../../terraform/stack_prod/locals.tf).
+Each Archivematica image tag contains an upstream revision, which may be a commit SHA or a release tag, followed by the overlay commit.
+For a release-tagged image, inspect the build script at the overlay commit and resolve the release tag in the upstream Archivematica repository.
 
 These upstream implementations are not completely consistent, so the Lambda deliberately adds stricter checks where accepting a row would cause an unhandled import failure or silently discard metadata:
 

--- a/lambdas/s3_start_transfer/README.md
+++ b/lambdas/s3_start_transfer/README.md
@@ -44,6 +44,33 @@ It records a success/fail result by uploading a small log file alongside the ori
 If it starts a transfer successfully, it tags the S3 object with the transfer ID.
 The [transfer monitor Lambda](../transfer_monitor) uses these tags to report Archivematica successes and failures and remove successfully stored packages from the transfer bucket.
 
+## Rights CSV validation
+
+The supported Wellcome transfer-package contract is documented in [Creating a transfer package](../../docs/storing-born-digital-files/creating-a-transfer-package.md).
+The Lambda validates that contract locally before submitting a transfer; it does not call Archivematica's validation API.
+
+The upstream reference for this contract is Archivematica's `qa/1.x` branch:
+
+*   Archivematica's [`RightsValidator`](https://github.com/artefactual/archivematica/blob/qa/1.x/src/archivematica/dashboard/components/api/validators.py) defines the intended CSV schema, including allowed columns, basis-specific fields, documentation identifiers, and grant restrictions.
+*   Archivematica's [`rights_from_csv.py`](https://github.com/artefactual/archivematica/blob/qa/1.x/src/archivematica/MCPClient/clientScripts/rights_from_csv.py) is the actual importer and therefore determines which values are persisted or cause an import failure.
+
+These source links intentionally follow `qa/1.x`, while [the image build](../../archivematica-apps/archivematica/build_and_publish_image.sh) pins a commit selected from that branch for a reproducible image.
+The final upstream and Wellcome overlay commit hashes can vary as images are updated or environments are rolled independently.
+To identify the exact revisions selected for deployment, inspect the `ecr_image_tags` variables in the [staging locals](../../terraform/stack_staging/locals.tf) or [production locals](../../terraform/stack_prod/locals.tf), where each Archivematica image tag contains the upstream commit followed by the overlay commit.
+
+These upstream implementations are not completely consistent, so the Lambda deliberately adds stricter checks where accepting a row would cause an unhandled import failure or silently discard metadata:
+
+*   Every `objects/` path must resolve to a real, non-metadata file in the transfer package.
+*   A populated basis-specific field is accepted only when `rights_from_csv.py` persists that field for the selected basis.
+*   Any grant information requires both `grant_act` and `grant_restriction`, because the importer only persists a grant when `grant_act` has a value.
+*   Any documentation identifier requires both `doc_id_type` and `doc_id_value`, following the upstream validator's stated requirement rather than its more permissive conditional.
+*   Each normalized file, basis, and grant-act combination may appear only once, because the importer silently skips later duplicates.
+*   Copyright rows cannot use `open` as their `end_date`, because the importer version selected from `qa/1.x` does not set the open-ended flag correctly for that basis.
+*   Duplicate headings, malformed row widths, non-UTF-8 input, UTF-8 byte-order marks, and empty files are rejected with depositor-facing messages.
+
+When `qa/1.x` or a deployed image revision changes, compare both upstream files with `verify_rights_csv_is_valid`, its tests, and the transfer-package documentation.
+If the upstream validator and importer disagree, preserve importer compatibility first and document any intentionally stricter Wellcome rule.
+
 ## Idempotency
 
 S3 and Lambda can deliver the same notification more than once.

--- a/lambdas/s3_start_transfer/src/s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/src/s3_start_transfer.py
@@ -18,6 +18,7 @@ from verify_transfer_packages import (
     VerificationFailure,
     verify_has_a_metadata_csv,
     verify_only_metadata_and_rights_csv_in_metadata_dir,
+    verify_rights_csv_is_valid,
     verify_metadata_csv_has_accession_fields,
     verify_metadata_csv_has_dc_identifier,
     verify_package,
@@ -74,6 +75,7 @@ def verify_s3_package(sess, *, logger, bucket, key, log_id, event_time):
         # verify_all_files_not_under_objects_dir,
         verify_has_a_metadata_csv,
         verify_only_metadata_and_rights_csv_in_metadata_dir,
+        verify_rights_csv_is_valid,
     ]
 
     if key.startswith("born-digital-accessions/"):

--- a/lambdas/s3_start_transfer/src/verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/src/verify_transfer_packages.py
@@ -4,9 +4,10 @@ it wrong that are non-obvious.
 
 This runs some checks over the package before sending it to Archivematica.
 
-It needs two things from the package:
+It needs three things from the package:
 *   The list of all files in the package (from zipfile.namelist())
 *   The contents of ``metadata/metadata.csv`` (if present in the package)
+*   The contents of ``metadata/rights.csv`` (if present in the package)
 
 """
 
@@ -22,28 +23,37 @@ class VerificationFailure(Exception):
         super().__init__(textwrap.dedent(message).strip())
 
 
-def extract_metadata(zip_file):
+def extract_csv(zip_file, path):
     try:
-        metadata_csv = zip_file.open("metadata/metadata.csv")
+        csv_file = zip_file.open(path)
     except KeyError:
         return None
     else:
-        metadata = metadata_csv.read().decode("utf8")
+        csv_contents = csv_file.read().decode("utf8")
 
         # Replace any byte-order marks in the CSV, we don't need them.
         # These are sometimes written by Excel and the like, I think?
-        if "\ufeff" in metadata:
-            metadata = metadata.replace("\ufeff", "")
+        if "\ufeff" in csv_contents:
+            csv_contents = csv_contents.replace("\ufeff", "")
 
-        return metadata
+        return csv_contents
+
+
+def extract_metadata(zip_file):
+    return extract_csv(zip_file, "metadata/metadata.csv")
+
+
+def extract_rights_metadata(zip_file):
+    return extract_csv(zip_file, "metadata/rights.csv")
 
 
 def verify_package(*, logger, zip_file, verifications):
-    # Extract the zip file listing and the metadata.csv contents for this
-    # transfer package.
+    # Extract the zip file listing and metadata CSV contents for this transfer
+    # package.
     file_listing = zip_file.namelist()
 
     metadata = extract_metadata(zip_file)
+    rights_metadata = extract_rights_metadata(zip_file)
 
     logger.write(f"Running {len(verifications)} checks for {zip_file}")
 
@@ -61,6 +71,9 @@ def verify_package(*, logger, zip_file, verifications):
 
         if "metadata" in inspect.getfullargspec(verify_function).args:
             kwargs["metadata"] = metadata
+
+        if "rights_metadata" in inspect.getfullargspec(verify_function).args:
+            kwargs["rights_metadata"] = rights_metadata
 
         try:
             verify_function(**kwargs)
@@ -206,6 +219,162 @@ def verify_only_metadata_and_rights_csv_in_metadata_dir(file_listing):
 
             """
         )
+
+
+RIGHTS_CSV_REQUIRED_COLUMNS = {"file", "basis"}
+RIGHTS_CSV_OPTIONAL_COLUMNS = {
+    "status",
+    "determination_date",
+    "start_date",
+    "end_date",
+    "jurisdiction",
+    "terms",
+    "citation",
+    "note",
+    "grant_act",
+    "grant_restriction",
+    "grant_start_date",
+    "grant_end_date",
+    "grant_note",
+    "doc_id_type",
+    "doc_id_value",
+    "doc_id_role",
+}
+RIGHTS_CSV_ALLOWED_COLUMNS = RIGHTS_CSV_REQUIRED_COLUMNS | RIGHTS_CSV_OPTIONAL_COLUMNS
+RIGHTS_CSV_ALLOWED_BASES = {
+    "copyright",
+    "donor",
+    "license",
+    "other",
+    "policy",
+    "statute",
+}
+RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS = {"allow", "conditional", "disallow"}
+RIGHTS_CSV_REQUIRED_FIELDS_BY_BASIS = {
+    "copyright": {"status", "jurisdiction"},
+    "statute": {"citation", "jurisdiction"},
+}
+
+
+def verify_rights_csv_is_valid(rights_metadata):
+    if rights_metadata is None:
+        return
+
+    csv_reader = csv.DictReader(io.StringIO(rights_metadata))
+
+    if csv_reader.fieldnames is None:
+        raise VerificationFailure(
+            """
+            Your rights.csv is empty. It must have a header row and at least one
+            row of rights information.
+            """
+        )
+
+    duplicate_columns = {
+        column
+        for column in csv_reader.fieldnames
+        if csv_reader.fieldnames.count(column) > 1
+    }
+    if duplicate_columns:
+        raise VerificationFailure(
+            f"""
+            Your rights.csv has duplicate column headings: {', '.join(sorted(duplicate_columns))}.
+
+            Each column heading may only appear once.
+            """
+        )
+
+    supplied_columns = set(csv_reader.fieldnames)
+    unexpected_columns = supplied_columns - RIGHTS_CSV_ALLOWED_COLUMNS
+    if unexpected_columns:
+        raise VerificationFailure(
+            f"""
+            Your rights.csv has unsupported column headings: {', '.join(sorted(unexpected_columns))}.
+
+            See the transfer-package documentation for the supported columns.
+            """
+        )
+
+    missing_columns = RIGHTS_CSV_REQUIRED_COLUMNS - supplied_columns
+    if missing_columns:
+        raise VerificationFailure(
+            f"""
+            Your rights.csv is missing mandatory column headings: {', '.join(sorted(missing_columns))}.
+
+            Add the missing columns, then upload a new transfer package.
+            """
+        )
+
+    rows = list(csv_reader)
+    if not rows:
+        raise VerificationFailure(
+            """
+            Your rights.csv has no rights information. Add at least one row, or
+            remove the file from the transfer package.
+            """
+        )
+
+    for row_number, row in enumerate(rows, start=2):
+        if row.get(None):
+            raise VerificationFailure(
+                f"""
+                Row {row_number} of your rights.csv has more values than column
+                headings.
+
+                Check that every value containing a comma is quoted.
+                """
+            )
+
+        for column in RIGHTS_CSV_REQUIRED_COLUMNS:
+            if not (row.get(column) or "").strip():
+                raise VerificationFailure(
+                    f"""
+                    Row {row_number} of your rights.csv has an empty '{column}' value.
+
+                    The 'file' and 'basis' values are required for every row.
+                    """
+                )
+
+        if not row["file"].strip().startswith("objects/"):
+            raise VerificationFailure(
+                f"""
+                Row {row_number} of your rights.csv has an invalid file value:
+                {row['file']}.
+
+                The file path must begin with 'objects/'.
+                """
+            )
+
+        basis = row["basis"].strip().lower()
+        if basis not in RIGHTS_CSV_ALLOWED_BASES:
+            raise VerificationFailure(
+                f"""
+                Row {row_number} of your rights.csv has an unsupported basis: {row['basis']}.
+
+                The basis must be one of: {', '.join(sorted(RIGHTS_CSV_ALLOWED_BASES))}.
+                """
+            )
+
+        for column in RIGHTS_CSV_REQUIRED_FIELDS_BY_BASIS.get(basis, set()):
+            if not (row.get(column) or "").strip():
+                raise VerificationFailure(
+                    f"""
+                    Row {row_number} of your rights.csv is missing a '{column}' value.
+
+                    It is required when the basis is '{basis}'.
+                    """
+                )
+
+        restriction = (row.get("grant_restriction") or "").strip().lower()
+        if restriction and restriction not in RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS:
+            raise VerificationFailure(
+                f"""
+                Row {row_number} of your rights.csv has an unsupported
+                grant_restriction value: {row['grant_restriction']}.
+
+                The value must be one of: {', '.join(sorted(RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS))}.
+                """
+            )
 
 
 def verify_metadata_csv_has_dc_identifier(metadata):

--- a/lambdas/s3_start_transfer/src/verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/src/verify_transfer_packages.py
@@ -41,18 +41,18 @@ def extract_csv(zip_file, path, *, reject_byte_order_mark=False):
                 """
             ) from err
 
-        if "\ufeff" in csv_contents:
-            if reject_byte_order_mark:
-                raise VerificationFailure(
-                    f"""
-                    The ``{path}`` file in your transfer package contains a UTF-8
-                    byte-order mark (BOM).
+        if reject_byte_order_mark and csv_contents.startswith("\ufeff"):
+            raise VerificationFailure(
+                f"""
+                The ``{path}`` file in your transfer package contains a UTF-8
+                byte-order mark (BOM).
 
-                    Save the CSV using UTF-8 without a BOM, recompress the package,
-                    and upload it again.
-                    """
-                )
+                Save the CSV using UTF-8 without a BOM, recompress the package,
+                and upload it again.
+                """
+            )
 
+        if not reject_byte_order_mark and "\ufeff" in csv_contents:
             # Retain the existing tolerance for metadata.csv files created by
             # software which writes a byte-order mark.
             csv_contents = csv_contents.replace("\ufeff", "")
@@ -347,6 +347,22 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
 
     csv_reader = csv.DictReader(io.StringIO(rights_metadata, newline=""))
 
+    try:
+        _verify_rights_csv_reader_is_valid(csv_reader, file_listing)
+    except csv.Error as err:
+        line_number = csv_reader.line_num + 1
+        raise VerificationFailure(
+            f"""
+            Line {line_number} of your rights.csv could not be read as CSV:
+            {err}.
+
+            Check that the row is valid CSV and that individual values are not
+            excessively large.
+            """
+        ) from err
+
+
+def _verify_rights_csv_reader_is_valid(csv_reader, file_listing):
     if csv_reader.fieldnames is None:
         raise VerificationFailure(
             """
@@ -409,6 +425,22 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
                 headings.
 
                 Check that every value containing a comma is quoted.
+                """
+            )
+
+        missing_values = [
+            column
+            for column, value in row.items()
+            if column is not None and value is None
+        ]
+        if missing_values:
+            raise VerificationFailure(
+                f"""
+                Line {line_number} of your rights.csv has fewer values than column
+                headings.
+
+                Add an empty value for every unused trailing column.
+                Missing values: {', '.join(missing_values)}.
                 """
             )
 
@@ -488,7 +520,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
                 end_date for a copyright basis.
 
                 This Archivematica version does not import that value correctly.
-                Supply a date or leave the value empty.
+                Leave the value empty instead.
                 """
             )
 
@@ -541,7 +573,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
                 """
             )
 
-        grant_act = (row.get("grant_act") or "").strip().lower()
+        grant_act = (row.get("grant_act") or "").strip().lower().capitalize()
         imported_combination = (file_path, basis, grant_act)
         if imported_combination in imported_combinations:
             raise VerificationFailure(

--- a/lambdas/s3_start_transfer/src/verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/src/verify_transfer_packages.py
@@ -250,13 +250,20 @@ RIGHTS_CSV_ALLOWED_BASES = {
     "statute",
 }
 RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS = {"allow", "conditional", "disallow"}
+RIGHTS_CSV_GRANT_COLUMNS = {
+    "grant_act",
+    "grant_restriction",
+    "grant_start_date",
+    "grant_end_date",
+    "grant_note",
+}
 RIGHTS_CSV_REQUIRED_FIELDS_BY_BASIS = {
     "copyright": {"status", "jurisdiction"},
     "statute": {"citation", "jurisdiction"},
 }
 
 
-def verify_rights_csv_is_valid(rights_metadata):
+def verify_rights_csv_is_valid(rights_metadata, file_listing):
     if rights_metadata is None:
         return
 
@@ -314,6 +321,12 @@ def verify_rights_csv_is_valid(rights_metadata):
             """
         )
 
+    package_files = {
+        path
+        for path in file_listing
+        if not path.endswith("/") and not path.startswith("metadata/")
+    }
+
     for row_number, row in enumerate(rows, start=2):
         if row.get(None):
             raise VerificationFailure(
@@ -335,13 +348,26 @@ def verify_rights_csv_is_valid(rights_metadata):
                     """
                 )
 
-        if not row["file"].strip().startswith("objects/"):
+        file_path = row["file"].strip()
+        if not file_path.startswith("objects/"):
             raise VerificationFailure(
                 f"""
                 Row {row_number} of your rights.csv has an invalid file value:
                 {row['file']}.
 
                 The file path must begin with 'objects/'.
+                """
+            )
+
+        package_path = file_path[len("objects/") :]
+        if package_path not in package_files:
+            raise VerificationFailure(
+                f"""
+                Row {row_number} of your rights.csv refers to a file that is not
+                present in the transfer package: {file_path}.
+
+                The 'file' value must identify a file in the package, using the
+                'objects/' prefix.
                 """
             )
 
@@ -364,6 +390,24 @@ def verify_rights_csv_is_valid(rights_metadata):
                     It is required when the basis is '{basis}'.
                     """
                 )
+
+        supplied_grant_columns = {
+            column
+            for column in RIGHTS_CSV_GRANT_COLUMNS
+            if (row.get(column) or "").strip()
+        }
+        if supplied_grant_columns and not {
+            "grant_act",
+            "grant_restriction",
+        }.issubset(supplied_grant_columns):
+            raise VerificationFailure(
+                f"""
+                Row {row_number} of your rights.csv has incomplete grant information.
+
+                If any grant information is supplied, both 'grant_act' and
+                'grant_restriction' must have values.
+                """
+            )
 
         restriction = (row.get("grant_restriction") or "").strip().lower()
         if restriction and restriction not in RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS:

--- a/lambdas/s3_start_transfer/src/verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/src/verify_transfer_packages.py
@@ -29,7 +29,17 @@ def extract_csv(zip_file, path):
     except KeyError:
         return None
     else:
-        csv_contents = csv_file.read().decode("utf8")
+        try:
+            csv_contents = csv_file.read().decode("utf8")
+        except UnicodeDecodeError as err:
+            raise VerificationFailure(
+                f"""
+                The ``{path}`` file in your transfer package is not valid UTF-8.
+
+                Save the CSV using UTF-8 encoding, recompress the package, and
+                upload it again.
+                """
+            ) from err
 
         # Replace any byte-order marks in the CSV, we don't need them.
         # These are sometimes written by Excel and the like, I think?
@@ -52,10 +62,15 @@ def verify_package(*, logger, zip_file, verifications):
     # package.
     file_listing = zip_file.namelist()
 
-    metadata = extract_metadata(zip_file)
-    rights_metadata = extract_rights_metadata(zip_file)
-
     logger.write(f"Running {len(verifications)} checks for {zip_file}")
+
+    try:
+        metadata = extract_metadata(zip_file)
+        rights_metadata = extract_rights_metadata(zip_file)
+    except VerificationFailure as err:
+        logger.write("Check failed:\n")
+        logger.write(str(err) + "\n")
+        return False
 
     for i, verify_function in enumerate(verifications, start=1):
         logger.write(f"== Check {i}: {verify_function.__name__} ==")
@@ -312,26 +327,21 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
             """
         )
 
-    rows = list(csv_reader)
-    if not rows:
-        raise VerificationFailure(
-            """
-            Your rights.csv has no rights information. Add at least one row, or
-            remove the file from the transfer package.
-            """
-        )
-
     package_files = {
         path
         for path in file_listing
         if not path.endswith("/") and not path.startswith("metadata/")
     }
 
-    for row_number, row in enumerate(rows, start=2):
+    has_rights_information = False
+    for row in csv_reader:
+        has_rights_information = True
+        line_number = csv_reader.line_num
+
         if row.get(None):
             raise VerificationFailure(
                 f"""
-                Row {row_number} of your rights.csv has more values than column
+                Line {line_number} of your rights.csv has more values than column
                 headings.
 
                 Check that every value containing a comma is quoted.
@@ -342,7 +352,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
             if not (row.get(column) or "").strip():
                 raise VerificationFailure(
                     f"""
-                    Row {row_number} of your rights.csv has an empty '{column}' value.
+                    Line {line_number} of your rights.csv has an empty '{column}' value.
 
                     The 'file' and 'basis' values are required for every row.
                     """
@@ -352,7 +362,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
         if not file_path.startswith("objects/"):
             raise VerificationFailure(
                 f"""
-                Row {row_number} of your rights.csv has an invalid file value:
+                Line {line_number} of your rights.csv has an invalid file value:
                 {row['file']}.
 
                 The file path must begin with 'objects/'.
@@ -363,7 +373,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
         if package_path not in package_files:
             raise VerificationFailure(
                 f"""
-                Row {row_number} of your rights.csv refers to a file that is not
+                Line {line_number} of your rights.csv refers to a file that is not
                 present in the transfer package: {file_path}.
 
                 The 'file' value must identify a file in the package, using the
@@ -375,7 +385,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
         if basis not in RIGHTS_CSV_ALLOWED_BASES:
             raise VerificationFailure(
                 f"""
-                Row {row_number} of your rights.csv has an unsupported basis: {row['basis']}.
+                Line {line_number} of your rights.csv has an unsupported basis: {row['basis']}.
 
                 The basis must be one of: {', '.join(sorted(RIGHTS_CSV_ALLOWED_BASES))}.
                 """
@@ -385,7 +395,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
             if not (row.get(column) or "").strip():
                 raise VerificationFailure(
                     f"""
-                    Row {row_number} of your rights.csv is missing a '{column}' value.
+                    Line {line_number} of your rights.csv is missing a '{column}' value.
 
                     It is required when the basis is '{basis}'.
                     """
@@ -402,7 +412,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
         }.issubset(supplied_grant_columns):
             raise VerificationFailure(
                 f"""
-                Row {row_number} of your rights.csv has incomplete grant information.
+                Line {line_number} of your rights.csv has incomplete grant information.
 
                 If any grant information is supplied, both 'grant_act' and
                 'grant_restriction' must have values.
@@ -413,12 +423,20 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
         if restriction and restriction not in RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS:
             raise VerificationFailure(
                 f"""
-                Row {row_number} of your rights.csv has an unsupported
+                Line {line_number} of your rights.csv has an unsupported
                 grant_restriction value: {row['grant_restriction']}.
 
                 The value must be one of: {', '.join(sorted(RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS))}.
                 """
             )
+
+    if not has_rights_information:
+        raise VerificationFailure(
+            """
+            Your rights.csv has no rights information. Add at least one row, or
+            remove the file from the transfer package.
+            """
+        )
 
 
 def verify_metadata_csv_has_dc_identifier(metadata):

--- a/lambdas/s3_start_transfer/src/verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/src/verify_transfer_packages.py
@@ -23,7 +23,7 @@ class VerificationFailure(Exception):
         super().__init__(textwrap.dedent(message).strip())
 
 
-def extract_csv(zip_file, path):
+def extract_csv(zip_file, path, *, reject_byte_order_mark=False):
     try:
         csv_file = zip_file.open(path)
     except KeyError:
@@ -41,9 +41,20 @@ def extract_csv(zip_file, path):
                 """
             ) from err
 
-        # Replace any byte-order marks in the CSV, we don't need them.
-        # These are sometimes written by Excel and the like, I think?
         if "\ufeff" in csv_contents:
+            if reject_byte_order_mark:
+                raise VerificationFailure(
+                    f"""
+                    The ``{path}`` file in your transfer package contains a UTF-8
+                    byte-order mark (BOM).
+
+                    Save the CSV using UTF-8 without a BOM, recompress the package,
+                    and upload it again.
+                    """
+                )
+
+            # Retain the existing tolerance for metadata.csv files created by
+            # software which writes a byte-order mark.
             csv_contents = csv_contents.replace("\ufeff", "")
 
         return csv_contents
@@ -54,7 +65,11 @@ def extract_metadata(zip_file):
 
 
 def extract_rights_metadata(zip_file):
-    return extract_csv(zip_file, "metadata/rights.csv")
+    return extract_csv(
+        zip_file,
+        "metadata/rights.csv",
+        reject_byte_order_mark=True,
+    )
 
 
 def verify_package(*, logger, zip_file, verifications):
@@ -204,7 +219,8 @@ def verify_only_metadata_and_rights_csv_in_metadata_dir(file_listing):
         raise VerificationFailure(
             """
             Your transfer package has unexpected files in the ``metadata/`` folder.
-            The only file in ``metadata/`` should be ``metadata/metadata.csv``.
+            The only files allowed in ``metadata/`` are ``metadata/metadata.csv``
+            and the optional ``metadata/rights.csv``.
 
             Move the other files to a different directory, recompress your transfer
             package, then upload it again.
@@ -236,6 +252,11 @@ def verify_only_metadata_and_rights_csv_in_metadata_dir(file_listing):
         )
 
 
+# The rights schema is derived from RightsValidator and rights_from_csv.py on
+# Archivematica's qa/1.x branch. The Lambda intentionally strengthens several
+# inconsistent upstream checks to prevent import failures or silently discarded
+# metadata. See the README's "Rights CSV validation" section for the deployed
+# revision and source-of-truth hierarchy.
 RIGHTS_CSV_REQUIRED_COLUMNS = {"file", "basis"}
 RIGHTS_CSV_OPTIONAL_COLUMNS = {
     "status",
@@ -276,13 +297,55 @@ RIGHTS_CSV_REQUIRED_FIELDS_BY_BASIS = {
     "copyright": {"status", "jurisdiction"},
     "statute": {"citation", "jurisdiction"},
 }
+RIGHTS_CSV_BASIS_FIELDS = {
+    "status",
+    "determination_date",
+    "start_date",
+    "end_date",
+    "jurisdiction",
+    "terms",
+    "citation",
+    "note",
+}
+RIGHTS_CSV_PERSISTED_FIELDS_BY_BASIS = {
+    "copyright": {
+        "status",
+        "determination_date",
+        "start_date",
+        "end_date",
+        "jurisdiction",
+        "note",
+    },
+    "donor": {"start_date", "end_date", "note"},
+    "license": {"start_date", "end_date", "terms", "note"},
+    "other": {"start_date", "end_date", "note"},
+    "policy": {"start_date", "end_date", "note"},
+    "statute": {
+        "determination_date",
+        "start_date",
+        "end_date",
+        "jurisdiction",
+        "citation",
+        "note",
+    },
+}
+RIGHTS_CSV_UNSUPPORTED_FIELDS_BY_BASIS = {
+    basis: RIGHTS_CSV_BASIS_FIELDS - persisted_fields
+    for basis, persisted_fields in RIGHTS_CSV_PERSISTED_FIELDS_BY_BASIS.items()
+}
+RIGHTS_CSV_DOCUMENTATION_COLUMNS = {
+    "doc_id_type",
+    "doc_id_value",
+    "doc_id_role",
+}
+RIGHTS_CSV_REQUIRED_DOCUMENTATION_COLUMNS = {"doc_id_type", "doc_id_value"}
 
 
 def verify_rights_csv_is_valid(rights_metadata, file_listing):
     if rights_metadata is None:
         return
 
-    csv_reader = csv.DictReader(io.StringIO(rights_metadata))
+    csv_reader = csv.DictReader(io.StringIO(rights_metadata, newline=""))
 
     if csv_reader.fieldnames is None:
         raise VerificationFailure(
@@ -334,6 +397,7 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
     }
 
     has_rights_information = False
+    imported_combinations = set()
     for row in csv_reader:
         has_rights_information = True
         line_number = csv_reader.line_num
@@ -401,6 +465,53 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
                     """
                 )
 
+        unsupported_fields = {
+            column
+            for column in RIGHTS_CSV_UNSUPPORTED_FIELDS_BY_BASIS.get(basis, set())
+            if (row.get(column) or "").strip()
+        }
+        if unsupported_fields:
+            raise VerificationFailure(
+                f"""
+                Line {line_number} of your rights.csv has fields that do not apply
+                to the '{basis}' basis: {', '.join(sorted(unsupported_fields))}.
+
+                Remove those values, then upload a new transfer package.
+                """
+            )
+
+        end_date = (row.get("end_date") or "").strip().lower()
+        if basis == "copyright" and end_date == "open":
+            raise VerificationFailure(
+                f"""
+                Line {line_number} of your rights.csv cannot use 'open' as the
+                end_date for a copyright basis.
+
+                This Archivematica version does not import that value correctly.
+                Supply a date or leave the value empty.
+                """
+            )
+
+        supplied_documentation_columns = {
+            column
+            for column in RIGHTS_CSV_DOCUMENTATION_COLUMNS
+            if (row.get(column) or "").strip()
+        }
+        if supplied_documentation_columns and not (
+            RIGHTS_CSV_REQUIRED_DOCUMENTATION_COLUMNS.issubset(
+                supplied_documentation_columns
+            )
+        ):
+            raise VerificationFailure(
+                f"""
+                Line {line_number} of your rights.csv has incomplete documentation
+                identifier information.
+
+                If any documentation identifier information is supplied, both
+                'doc_id_type' and 'doc_id_value' must have values.
+                """
+            )
+
         supplied_grant_columns = {
             column
             for column in RIGHTS_CSV_GRANT_COLUMNS
@@ -429,6 +540,20 @@ def verify_rights_csv_is_valid(rights_metadata, file_listing):
                 The value must be one of: {', '.join(sorted(RIGHTS_CSV_ALLOWED_GRANT_RESTRICTIONS))}.
                 """
             )
+
+        grant_act = (row.get("grant_act") or "").strip().lower()
+        imported_combination = (file_path, basis, grant_act)
+        if imported_combination in imported_combinations:
+            raise VerificationFailure(
+                f"""
+                Line {line_number} of your rights.csv duplicates a file, basis,
+                and grant_act combination from an earlier row.
+
+                Archivematica would skip this row. Combine the information into
+                one row or use a different grant_act.
+                """
+            )
+        imported_combinations.add(imported_combination)
 
     if not has_rights_information:
         raise VerificationFailure(

--- a/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
@@ -278,6 +278,18 @@ class TestStartTransfer:
                 b"The ``metadata/rights.csv`` file in your transfer package "
                 b"is not valid UTF-8",
             ),
+            pytest.param(
+                _package_with_metadata(
+                    b"filename,dc.identifier\nobjects/,LEMON\n",
+                    rights_metadata=(
+                        b"file,basis,note\nobjects/record.txt,policy,"
+                        + (b"a" * 131_073)
+                        + b"\n"
+                    ),
+                ),
+                b"Line 2 of your rights.csv could not be read as CSV",
+                id="oversized-rights-value",
+            ),
         ],
     )
     def test_malformed_package_writes_failed_log_without_starting_transfer(

--- a/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
@@ -204,6 +204,35 @@ class TestStartTransfer:
     @mock_aws
     @patch.object(archivematica, "start_transfer")
     @patch.object(archivematica, "get_target_path")
+    def test_invalid_rights_schema_writes_failed_log_without_starting_transfer(
+        self,
+        mock_get_target_path,
+        mock_start_transfer,
+        bucket_name,
+    ):
+        sess = boto3.Session()
+        body = _package_with_metadata(
+            b"filename,dc.identifier\nobjects/,LEMON\n",
+            rights_metadata=b"file,status\nobjects/record.txt,copyrighted\n",
+        )
+        key = _write_package_bytes(sess, bucket_name=bucket_name, body=body)
+        event = _event(bucket_name, key)
+
+        s3_start_transfer.run_transfer(sess, event=event)
+
+        mock_get_target_path.assert_not_called()
+        mock_start_transfer.assert_not_called()
+
+        log_object = _find_log_object(sess, bucket_name=bucket_name)
+        assert log_object.key == _log_key(key, "failed", event)
+
+        log_text = log_object.get()["Body"].read()
+        assert b"verify_rights_csv_is_valid" in log_text
+        assert b"missing mandatory column headings: basis" in log_text
+
+    @mock_aws
+    @patch.object(archivematica, "start_transfer")
+    @patch.object(archivematica, "get_target_path")
     @pytest.mark.parametrize(
         "filename, key",
         [

--- a/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
+++ b/lambdas/s3_start_transfer/tests/test_s3_start_transfer.py
@@ -50,11 +50,13 @@ def _write_package_bytes(
     return key
 
 
-def _package_with_metadata(metadata):
+def _package_with_metadata(metadata, rights_metadata=None):
     archive = io.BytesIO()
     with zipfile.ZipFile(archive, "w") as zf:
         zf.writestr("record.txt", "test transfer")
         zf.writestr("metadata/metadata.csv", metadata)
+        if rights_metadata is not None:
+            zf.writestr("metadata/rights.csv", rights_metadata)
 
     return archive.getvalue()
 
@@ -230,10 +232,22 @@ class TestStartTransfer:
     @pytest.mark.parametrize(
         "body, expected_error",
         [
-            (b"not a ZIP archive", b"File is not a zip file"),
+            (
+                b"not a ZIP archive",
+                b"Unable to read transfer package: File is not a zip file",
+            ),
             (
                 _package_with_metadata(b"filename,dc.identifier\nobjects/,\xff\n"),
-                b"codec can't decode byte 0xff",
+                b"The ``metadata/metadata.csv`` file in your transfer package "
+                b"is not valid UTF-8",
+            ),
+            (
+                _package_with_metadata(
+                    b"filename,dc.identifier\nobjects/,LEMON\n",
+                    rights_metadata=b"file,basis\nobjects/record.txt,pol\xffcy\n",
+                ),
+                b"The ``metadata/rights.csv`` file in your transfer package "
+                b"is not valid UTF-8",
             ),
         ],
     )
@@ -258,7 +272,6 @@ class TestStartTransfer:
         assert log_object.key == _log_key(key, "failed", event)
 
         log_text = log_object.get()["Body"].read()
-        assert b"Unable to read transfer package:" in log_text
         assert expected_error in log_text
 
     @mock_aws

--- a/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
@@ -63,6 +63,26 @@ class TestVerifyPackage:
         with zipfile.ZipFile(zip_path) as zf:
             verify_package(logger=logger, zip_file=zf, verifications=self.verifications)
 
+    @pytest.mark.parametrize("path", ["metadata/metadata.csv", "metadata/rights.csv"])
+    def test_invalid_csv_encoding_is_logged_as_a_verification_failure(self, path):
+        contents = io.BytesIO()
+        with zipfile.ZipFile(contents, "w") as zf:
+            metadata = b"filename,dc.identifier\nobjects/,LEMON\n"
+            if path == "metadata/metadata.csv":
+                metadata = b"filename,dc.identifier\nobjects/,\xff\n"
+            zf.writestr("metadata/metadata.csv", metadata)
+
+            if path == "metadata/rights.csv":
+                zf.writestr(path, b"file,basis\nobjects/report.txt,pol\xffcy\n")
+
+        contents.seek(0)
+        logger = Logger()
+        with zipfile.ZipFile(contents) as zf:
+            assert not verify_package(logger=logger, zip_file=zf, verifications=[])
+
+        assert f"The ``{path}`` file" in logger.text()
+        assert "Save the CSV using UTF-8 encoding" in logger.text()
+
 
 class TestVerifyAllFilesNotUnderSingleDir:
     def test_single_dir_is_exception(self):
@@ -227,10 +247,38 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
             )
 
     @pytest.mark.parametrize(
+        "rights_metadata, line_number",
+        [
+            (
+                "file,basis\n\nobjects/reports/summary.pdf,unknown\n",
+                3,
+            ),
+            (
+                'file,basis,note\nobjects/reports/summary.pdf,policy,"First\n'
+                'line"\nobjects/reports/summary.pdf,unknown,\n',
+                4,
+            ),
+        ],
+    )
+    def test_reports_physical_line_number(self, rights_metadata, line_number):
+        with pytest.raises(
+            VerificationFailure,
+            match=f"Line {line_number} of your rights.csv has an unsupported basis",
+        ):
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+    @pytest.mark.parametrize(
         "rights_metadata, message",
         [
             ("", "Your rights.csv is empty."),
             ("file,basis\n", "Your rights.csv has no rights information."),
+            (
+                "file,basis,basis\n" "objects/reports/summary.pdf,policy,policy\n",
+                "Your rights.csv has duplicate column headings: basis.",
+            ),
             (
                 "file,status\nobjects/reports/summary.pdf,copyrighted\n",
                 "Your rights.csv is missing mandatory column headings: basis.",
@@ -240,29 +288,33 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
                 "Your rights.csv has unsupported column headings: unsupported.",
             ),
             (
+                "file,basis\nobjects/reports/summary.pdf,policy,extra\n",
+                "Line 2 of your rights.csv has more values than column",
+            ),
+            (
                 "file,basis\nobjects/reports/summary.pdf,\n",
-                "Row 2 of your rights.csv has an empty 'basis' value.",
+                "Line 2 of your rights.csv has an empty 'basis' value.",
             ),
             (
                 "file,basis\nreports/summary.pdf,policy\n",
-                "Row 2 of your rights.csv has an invalid file value:",
+                "Line 2 of your rights.csv has an invalid file value:",
             ),
             (
                 "file,basis\nobjects/reports/summary.pdf,unknown\n",
-                "Row 2 of your rights.csv has an unsupported basis: unknown.",
+                "Line 2 of your rights.csv has an unsupported basis: unknown.",
             ),
             (
                 "file,basis,jurisdiction\nobjects/reports/summary.pdf,copyright,GB\n",
-                "Row 2 of your rights.csv is missing a 'status' value.",
+                "Line 2 of your rights.csv is missing a 'status' value.",
             ),
             (
                 "file,basis,jurisdiction\nobjects/reports/summary.pdf,statute,GB\n",
-                "Row 2 of your rights.csv is missing a 'citation' value.",
+                "Line 2 of your rights.csv is missing a 'citation' value.",
             ),
             (
                 "file,basis,grant_act,grant_restriction\n"
                 "objects/reports/summary.pdf,policy,disseminate,maybe\n",
-                "Row 2 of your rights.csv has an unsupported",
+                "Line 2 of your rights.csv has an unsupported",
             ),
         ],
     )

--- a/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8
 
+import csv
 import io
 import pathlib
 import textwrap
@@ -30,6 +31,57 @@ def _get_file_listing(name):
 
     with zipfile.ZipFile(zip_path) as zf:
         return zf.namelist()
+
+
+def _make_rights_csv(*rows, lineterminator="\n"):
+    fieldnames = list(dict.fromkeys(key for row in rows for key in row))
+    contents = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        contents,
+        fieldnames=fieldnames,
+        lineterminator=lineterminator,
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    return contents.getvalue()
+
+
+_RIGHTS_BASIS_FIELD_VALUES = {
+    "status": "copyrighted",
+    "determination_date": "2026-01-01",
+    "start_date": "2026-01-01",
+    "end_date": "2026-12-31",
+    "jurisdiction": "GB",
+    "terms": "Example licence terms",
+    "citation": "Example Act 2026",
+    "note": "Example rights note",
+}
+_RIGHTS_PERSISTED_FIELDS_BY_BASIS = {
+    "copyright": (
+        "status",
+        "determination_date",
+        "start_date",
+        "end_date",
+        "jurisdiction",
+        "note",
+    ),
+    "donor": ("start_date", "end_date", "note"),
+    "license": ("start_date", "end_date", "terms", "note"),
+    "other": ("start_date", "end_date", "note"),
+    "policy": ("start_date", "end_date", "note"),
+    "statute": (
+        "determination_date",
+        "start_date",
+        "end_date",
+        "jurisdiction",
+        "citation",
+        "note",
+    ),
+}
+_RIGHTS_REQUIRED_FIELDS_BY_BASIS = {
+    "copyright": {"status": "copyrighted", "jurisdiction": "GB"},
+    "statute": {"citation": "Example Act 2026", "jurisdiction": "GB"},
+}
 
 
 class TestVerifyPackage:
@@ -82,6 +134,36 @@ class TestVerifyPackage:
 
         assert f"The ``{path}`` file" in logger.text()
         assert "Save the CSV using UTF-8 encoding" in logger.text()
+
+    @pytest.mark.parametrize(
+        "rights_metadata",
+        [
+            pytest.param(
+                b"\xef\xbb\xbffile,basis\nobjects/report.txt,policy\n",
+                id="leading-bom",
+            ),
+            pytest.param(
+                b"file,basis,note\nobjects/report.txt,policy,\xef\xbb\xbf\n",
+                id="embedded-bom",
+            ),
+        ],
+    )
+    def test_rights_csv_byte_order_mark_is_logged_as_a_failure(self, rights_metadata):
+        contents = io.BytesIO()
+        with zipfile.ZipFile(contents, "w") as zf:
+            zf.writestr(
+                "metadata/metadata.csv",
+                b"filename,dc.identifier\nobjects/,LEMON\n",
+            )
+            zf.writestr("metadata/rights.csv", rights_metadata)
+
+        contents.seek(0)
+        logger = Logger()
+        with zipfile.ZipFile(contents) as zf:
+            assert not verify_package(logger=logger, zip_file=zf, verifications=[])
+
+        assert "byte-order mark (BOM)" in logger.text()
+        assert "Save the CSV using UTF-8 without a BOM" in logger.text()
 
 
 class TestVerifyAllFilesNotUnderSingleDir:
@@ -158,7 +240,8 @@ class TestVerifyOnlyMetadataAndRightsCsvInMetadataDir:
 
         assert str(err.value).startswith(
             "Your transfer package has unexpected files in the ``metadata/`` folder.\n"
-            "The only file in ``metadata/`` should be ``metadata/metadata.csv``."
+            "The only files allowed in ``metadata/`` are ``metadata/metadata.csv``\n"
+            "and the optional ``metadata/rights.csv``."
         )
 
     @pytest.mark.parametrize(
@@ -178,6 +261,7 @@ class TestVerifyOnlyMetadataAndRightsCsvInMetadataDir:
 
 
 class TestVerifyRightsCsv:
+    file_path = "objects/reports/summary.pdf"
     file_listing = ["reports/summary.pdf", "metadata/rights.csv"]
     valid_rights_metadata = """\
 file,basis,status,jurisdiction,grant_act,grant_restriction
@@ -190,6 +274,106 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
     def test_valid_rights_csv_is_okay(self):
         verify_rights_csv_is_valid(
             rights_metadata=self.valid_rights_metadata,
+            file_listing=self.file_listing,
+        )
+
+    @pytest.mark.parametrize(
+        "basis, extra_values",
+        [
+            pytest.param(
+                "copyright",
+                {"status": "copyrighted", "jurisdiction": "GB"},
+                id="copyright",
+            ),
+            pytest.param("donor", {}, id="donor"),
+            pytest.param("license", {}, id="license"),
+            pytest.param("other", {}, id="other"),
+            pytest.param("policy", {}, id="policy"),
+            pytest.param(
+                "statute",
+                {"citation": "Example Act 2026", "jurisdiction": "GB"},
+                id="statute",
+            ),
+        ],
+    )
+    def test_accepts_supported_bases(self, basis, extra_values):
+        rights_metadata = _make_rights_csv(
+            {"file": self.file_path, "basis": basis, **extra_values}
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=self.file_listing,
+        )
+
+    @pytest.mark.parametrize("restriction", ["allow", "conditional", "disallow"])
+    def test_accepts_supported_grant_restrictions(self, restriction):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": "policy",
+                "grant_act": "disseminate",
+                "grant_restriction": restriction,
+            }
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=self.file_listing,
+        )
+
+    @pytest.mark.parametrize("role", [None, "source"])
+    def test_accepts_complete_documentation_identifier(self, role):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": "policy",
+                "doc_id_type": "URL",
+                "doc_id_value": "https://example.com/rights",
+                "doc_id_role": role,
+            }
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=self.file_listing,
+        )
+
+    def test_accepts_complete_rights_metadata(self):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": "copyright",
+                "status": "copyrighted",
+                "determination_date": "2026-01-01",
+                "start_date": "2026-01-01",
+                "end_date": "2026-12-31",
+                "jurisdiction": "GB",
+                "note": "Copyright statement",
+                "grant_act": "disseminate",
+                "grant_restriction": "disallow",
+                "grant_start_date": "2026-01-01",
+                "grant_end_date": "open",
+                "grant_note": "Reading room only",
+                "doc_id_type": "URL",
+                "doc_id_value": "https://example.com/rights",
+                "doc_id_role": "source",
+            },
+            {
+                "file": self.file_path,
+                "basis": "license",
+                "terms": "Example licence terms",
+            },
+            {
+                "file": self.file_path,
+                "basis": "statute",
+                "citation": "Example Act 2026",
+                "jurisdiction": "GB",
+            },
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
             file_listing=self.file_listing,
         )
 
@@ -206,6 +390,35 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
                 zip_file=zf,
                 verifications=[verify_rights_csv_is_valid],
             )
+
+    def test_accepts_unicode_and_quoted_multiline_values(self):
+        first_path = "reports/Résumé, final.txt"
+        second_path = "reports/報告.txt"
+        rights_metadata = _make_rights_csv(
+            {
+                "file": f"objects/{first_path}",
+                "basis": "policy",
+                "note": "First line, with comma\nand second line",
+            },
+            {"file": f"objects/{second_path}", "basis": "policy"},
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=[first_path, second_path],
+        )
+
+    @pytest.mark.parametrize("lineterminator", ["\r\n", "\r"])
+    def test_accepts_supported_newlines(self, lineterminator):
+        rights_metadata = _make_rights_csv(
+            {"file": self.file_path, "basis": "policy"},
+            lineterminator=lineterminator,
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=self.file_listing,
+        )
 
     @pytest.mark.parametrize(
         "file_listing, file_path",
@@ -247,6 +460,230 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
             )
 
     @pytest.mark.parametrize(
+        "basis, supplied_field, supplied_value, missing_field",
+        [
+            ("copyright", "status", "copyrighted", "jurisdiction"),
+            ("copyright", "jurisdiction", "GB", "status"),
+            ("statute", "citation", "Example Act 2026", "jurisdiction"),
+            ("statute", "jurisdiction", "GB", "citation"),
+        ],
+    )
+    def test_requires_basis_specific_fields(
+        self,
+        basis,
+        supplied_field,
+        supplied_value,
+        missing_field,
+    ):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": basis,
+                supplied_field: supplied_value,
+            }
+        )
+
+        with pytest.raises(
+            VerificationFailure,
+            match=f"missing a '{missing_field}' value",
+        ):
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+    @pytest.mark.parametrize(
+        "basis, field",
+        [
+            pytest.param(basis, field, id=f"{basis}-{field}")
+            for basis, fields in _RIGHTS_PERSISTED_FIELDS_BY_BASIS.items()
+            for field in fields
+        ],
+    )
+    def test_accepts_fields_persisted_for_basis(self, basis, field):
+        rights_values = {
+            "file": self.file_path,
+            "basis": basis,
+            **_RIGHTS_REQUIRED_FIELDS_BY_BASIS.get(basis, {}),
+            field: _RIGHTS_BASIS_FIELD_VALUES[field],
+        }
+        rights_metadata = _make_rights_csv(rights_values)
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=self.file_listing,
+        )
+
+    @pytest.mark.parametrize(
+        "basis, field",
+        [
+            pytest.param(basis, field, id=f"{basis}-{field}")
+            for basis, persisted_fields in _RIGHTS_PERSISTED_FIELDS_BY_BASIS.items()
+            for field in sorted(
+                _RIGHTS_BASIS_FIELD_VALUES.keys() - set(persisted_fields)
+            )
+        ],
+    )
+    def test_rejects_fields_discarded_for_basis(self, basis, field):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": basis,
+                **_RIGHTS_REQUIRED_FIELDS_BY_BASIS.get(basis, {}),
+                field: _RIGHTS_BASIS_FIELD_VALUES[field],
+            }
+        )
+
+        with pytest.raises(VerificationFailure) as err:
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+        assert "has fields that do not apply" in str(err.value)
+        assert f"to the '{basis}' basis: {field}" in str(err.value)
+
+    @pytest.mark.parametrize("end_date", ["open", "OPEN", " open "])
+    def test_rejects_open_copyright_end_date(self, end_date):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": "copyright",
+                "status": "copyrighted",
+                "jurisdiction": "GB",
+                "end_date": end_date,
+            }
+        )
+
+        with pytest.raises(VerificationFailure, match="cannot use 'open'"):
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+    @pytest.mark.parametrize(
+        "basis", ["donor", "license", "other", "policy", "statute"]
+    )
+    def test_accepts_open_end_date_for_other_bases(self, basis):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": basis,
+                **_RIGHTS_REQUIRED_FIELDS_BY_BASIS.get(basis, {}),
+                "end_date": "open",
+            }
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=self.file_listing,
+        )
+
+    @pytest.mark.parametrize(
+        "documentation_values",
+        [
+            pytest.param({"doc_id_type": "URL"}, id="type-only"),
+            pytest.param(
+                {"doc_id_value": "https://example.com/rights"},
+                id="value-only",
+            ),
+            pytest.param({"doc_id_role": "source"}, id="role-only"),
+            pytest.param(
+                {"doc_id_type": "URL", "doc_id_role": "source"},
+                id="type-and-role",
+            ),
+            pytest.param(
+                {
+                    "doc_id_value": "https://example.com/rights",
+                    "doc_id_role": "source",
+                },
+                id="value-and-role",
+            ),
+        ],
+    )
+    def test_documentation_identifier_requires_type_and_value(
+        self, documentation_values
+    ):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": "policy",
+                **documentation_values,
+            }
+        )
+
+        with pytest.raises(VerificationFailure) as err:
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+        assert "has incomplete documentation" in str(err.value)
+        assert "identifier information" in str(err.value)
+
+    @pytest.mark.parametrize(
+        "rows",
+        [
+            pytest.param(
+                (
+                    {"file": "objects/reports/summary.pdf", "basis": "policy"},
+                    {"file": "objects/reports/summary.pdf", "basis": "policy"},
+                ),
+                id="exact-without-grant-act",
+            ),
+            pytest.param(
+                (
+                    {
+                        "file": "objects/reports/summary.pdf",
+                        "basis": "Policy",
+                        "grant_act": "Disseminate",
+                        "grant_restriction": "Allow",
+                    },
+                    {
+                        "file": " objects/reports/summary.pdf ",
+                        "basis": " policy ",
+                        "grant_act": " disseminate ",
+                        "grant_restriction": " allow ",
+                    },
+                ),
+                id="normalized-with-grant-act",
+            ),
+        ],
+    )
+    def test_rejects_duplicate_importer_combinations(self, rows):
+        rights_metadata = _make_rights_csv(*rows)
+
+        with pytest.raises(
+            VerificationFailure,
+            match="duplicates a file, basis,",
+        ):
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+    def test_accepts_different_grant_acts_for_same_file_and_basis(self):
+        rights_metadata = _make_rights_csv(
+            {
+                "file": self.file_path,
+                "basis": "policy",
+                "grant_act": "disseminate",
+                "grant_restriction": "allow",
+            },
+            {
+                "file": self.file_path,
+                "basis": "policy",
+                "grant_act": "delete",
+                "grant_restriction": "allow",
+            },
+        )
+
+        verify_rights_csv_is_valid(
+            rights_metadata=rights_metadata,
+            file_listing=self.file_listing,
+        )
+
+    @pytest.mark.parametrize(
         "rights_metadata, line_number",
         [
             (
@@ -284,12 +721,20 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
                 "Your rights.csv is missing mandatory column headings: basis.",
             ),
             (
+                "basis\npolicy\n",
+                "Your rights.csv is missing mandatory column headings: file.",
+            ),
+            (
                 "file,basis,unsupported\nobjects/reports/summary.pdf,policy,x\n",
                 "Your rights.csv has unsupported column headings: unsupported.",
             ),
             (
                 "file,basis\nobjects/reports/summary.pdf,policy,extra\n",
                 "Line 2 of your rights.csv has more values than column",
+            ),
+            (
+                "file,basis\n,policy\n",
+                "Line 2 of your rights.csv has an empty 'file' value.",
             ),
             (
                 "file,basis\nobjects/reports/summary.pdf,\n",
@@ -302,14 +747,6 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
             (
                 "file,basis\nobjects/reports/summary.pdf,unknown\n",
                 "Line 2 of your rights.csv has an unsupported basis: unknown.",
-            ),
-            (
-                "file,basis,jurisdiction\nobjects/reports/summary.pdf,copyright,GB\n",
-                "Line 2 of your rights.csv is missing a 'status' value.",
-            ),
-            (
-                "file,basis,jurisdiction\nobjects/reports/summary.pdf,statute,GB\n",
-                "Line 2 of your rights.csv is missing a 'citation' value.",
             ),
             (
                 "file,basis,grant_act,grant_restriction\n"

--- a/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8
 
+import io
 import pathlib
 import textwrap
 import zipfile
@@ -13,6 +14,7 @@ from verify_transfer_packages import (
     verify_all_files_not_under_objects_dir,
     verify_has_a_metadata_csv,
     verify_only_metadata_and_rights_csv_in_metadata_dir,
+    verify_rights_csv_is_valid,
     verify_metadata_csv_has_dc_identifier,
     verify_metadata_csv_has_accession_fields,
     VerificationFailure,
@@ -153,6 +155,75 @@ class TestVerifyOnlyMetadataAndRightsCsvInMetadataDir:
             "metadata/rights.csv",
         ]
         verify_only_metadata_and_rights_csv_in_metadata_dir(file_listing=file_listing)
+
+
+class TestVerifyRightsCsv:
+    valid_rights_metadata = """\
+file,basis,status,jurisdiction,grant_act,grant_restriction
+objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
+"""
+
+    def test_rights_csv_is_optional(self):
+        verify_rights_csv_is_valid(rights_metadata=None)
+
+    def test_valid_rights_csv_is_okay(self):
+        verify_rights_csv_is_valid(rights_metadata=self.valid_rights_metadata)
+
+    def test_rights_csv_is_passed_to_package_verification(self):
+        contents = io.BytesIO()
+        with zipfile.ZipFile(contents, "w") as zf:
+            zf.writestr("metadata/rights.csv", self.valid_rights_metadata)
+
+        contents.seek(0)
+        with zipfile.ZipFile(contents) as zf:
+            assert verify_package(
+                logger=Logger(),
+                zip_file=zf,
+                verifications=[verify_rights_csv_is_valid],
+            )
+
+    @pytest.mark.parametrize(
+        "rights_metadata, message",
+        [
+            ("", "Your rights.csv is empty."),
+            ("file,basis\n", "Your rights.csv has no rights information."),
+            (
+                "file,status\nobjects/reports/summary.pdf,copyrighted\n",
+                "Your rights.csv is missing mandatory column headings: basis.",
+            ),
+            (
+                "file,basis,unsupported\nobjects/reports/summary.pdf,policy,x\n",
+                "Your rights.csv has unsupported column headings: unsupported.",
+            ),
+            (
+                "file,basis\nobjects/reports/summary.pdf,\n",
+                "Row 2 of your rights.csv has an empty 'basis' value.",
+            ),
+            (
+                "file,basis\nreports/summary.pdf,policy\n",
+                "Row 2 of your rights.csv has an invalid file value:",
+            ),
+            (
+                "file,basis\nobjects/reports/summary.pdf,unknown\n",
+                "Row 2 of your rights.csv has an unsupported basis: unknown.",
+            ),
+            (
+                "file,basis,jurisdiction\nobjects/reports/summary.pdf,copyright,GB\n",
+                "Row 2 of your rights.csv is missing a 'status' value.",
+            ),
+            (
+                "file,basis,jurisdiction\nobjects/reports/summary.pdf,statute,GB\n",
+                "Row 2 of your rights.csv is missing a 'citation' value.",
+            ),
+            (
+                "file,basis,grant_restriction\nobjects/reports/summary.pdf,policy,maybe\n",
+                "Row 2 of your rights.csv has an unsupported",
+            ),
+        ],
+    )
+    def test_rejects_invalid_rights_csv(self, rights_metadata, message):
+        with pytest.raises(VerificationFailure, match=message):
+            verify_rights_csv_is_valid(rights_metadata=rights_metadata)
 
 
 class TestVerifyMetadataCsvHasDcIdentifier:

--- a/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
@@ -158,21 +158,26 @@ class TestVerifyOnlyMetadataAndRightsCsvInMetadataDir:
 
 
 class TestVerifyRightsCsv:
+    file_listing = ["reports/summary.pdf", "metadata/rights.csv"]
     valid_rights_metadata = """\
 file,basis,status,jurisdiction,grant_act,grant_restriction
 objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
 """
 
     def test_rights_csv_is_optional(self):
-        verify_rights_csv_is_valid(rights_metadata=None)
+        verify_rights_csv_is_valid(rights_metadata=None, file_listing=[])
 
     def test_valid_rights_csv_is_okay(self):
-        verify_rights_csv_is_valid(rights_metadata=self.valid_rights_metadata)
+        verify_rights_csv_is_valid(
+            rights_metadata=self.valid_rights_metadata,
+            file_listing=self.file_listing,
+        )
 
     def test_rights_csv_is_passed_to_package_verification(self):
         contents = io.BytesIO()
         with zipfile.ZipFile(contents, "w") as zf:
             zf.writestr("metadata/rights.csv", self.valid_rights_metadata)
+            zf.writestr("reports/summary.pdf", b"")
 
         contents.seek(0)
         with zipfile.ZipFile(contents) as zf:
@@ -180,6 +185,45 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
                 logger=Logger(),
                 zip_file=zf,
                 verifications=[verify_rights_csv_is_valid],
+            )
+
+    @pytest.mark.parametrize(
+        "file_listing, file_path",
+        [
+            (["reports/summary.pdf"], "objects/reports/missing.pdf"),
+            (["reports/"], "objects/reports/"),
+            (["metadata/rights.csv"], "objects/metadata/rights.csv"),
+        ],
+    )
+    def test_file_must_resolve_to_an_imported_file(self, file_listing, file_path):
+        rights_metadata = f"file,basis\n{file_path},policy\n"
+
+        with pytest.raises(VerificationFailure, match="refers to a file"):
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=file_listing,
+            )
+
+    @pytest.mark.parametrize(
+        "grant_column, value",
+        [
+            ("grant_act", "disseminate"),
+            ("grant_restriction", "allow"),
+            ("grant_start_date", "2026-01-01"),
+            ("grant_end_date", "2026-12-31"),
+            ("grant_note", "Only in the reading room"),
+        ],
+    )
+    def test_grant_fields_must_be_paired(self, grant_column, value):
+        rights_metadata = (
+            f"file,basis,{grant_column}\n"
+            f"objects/reports/summary.pdf,policy,{value}\n"
+        )
+
+        with pytest.raises(VerificationFailure, match="incomplete grant information"):
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
             )
 
     @pytest.mark.parametrize(
@@ -216,14 +260,18 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
                 "Row 2 of your rights.csv is missing a 'citation' value.",
             ),
             (
-                "file,basis,grant_restriction\nobjects/reports/summary.pdf,policy,maybe\n",
+                "file,basis,grant_act,grant_restriction\n"
+                "objects/reports/summary.pdf,policy,disseminate,maybe\n",
                 "Row 2 of your rights.csv has an unsupported",
             ),
         ],
     )
     def test_rejects_invalid_rights_csv(self, rights_metadata, message):
         with pytest.raises(VerificationFailure, match=message):
-            verify_rights_csv_is_valid(rights_metadata=rights_metadata)
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
 
 
 class TestVerifyMetadataCsvHasDcIdentifier:

--- a/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
+++ b/lambdas/s3_start_transfer/tests/test_verify_transfer_packages.py
@@ -135,27 +135,17 @@ class TestVerifyPackage:
         assert f"The ``{path}`` file" in logger.text()
         assert "Save the CSV using UTF-8 encoding" in logger.text()
 
-    @pytest.mark.parametrize(
-        "rights_metadata",
-        [
-            pytest.param(
-                b"\xef\xbb\xbffile,basis\nobjects/report.txt,policy\n",
-                id="leading-bom",
-            ),
-            pytest.param(
-                b"file,basis,note\nobjects/report.txt,policy,\xef\xbb\xbf\n",
-                id="embedded-bom",
-            ),
-        ],
-    )
-    def test_rights_csv_byte_order_mark_is_logged_as_a_failure(self, rights_metadata):
+    def test_rights_csv_byte_order_mark_is_logged_as_a_failure(self):
         contents = io.BytesIO()
         with zipfile.ZipFile(contents, "w") as zf:
             zf.writestr(
                 "metadata/metadata.csv",
                 b"filename,dc.identifier\nobjects/,LEMON\n",
             )
-            zf.writestr("metadata/rights.csv", rights_metadata)
+            zf.writestr(
+                "metadata/rights.csv",
+                b"\xef\xbb\xbffile,basis\nobjects/report.txt,policy\n",
+            )
 
         contents.seek(0)
         logger = Logger()
@@ -164,6 +154,23 @@ class TestVerifyPackage:
 
         assert "byte-order mark (BOM)" in logger.text()
         assert "Save the CSV using UTF-8 without a BOM" in logger.text()
+
+    def test_rights_csv_accepts_byte_order_mark_character_in_a_value(self):
+        contents = io.BytesIO()
+        with zipfile.ZipFile(contents, "w") as zf:
+            zf.writestr(
+                "metadata/rights.csv",
+                "file,basis,note\nobjects/report.txt,policy,\ufeff\n",
+            )
+            zf.writestr("report.txt", b"")
+
+        contents.seek(0)
+        with zipfile.ZipFile(contents) as zf:
+            assert verify_package(
+                logger=Logger(),
+                zip_file=zf,
+                verifications=[verify_rights_csv_is_valid],
+            )
 
 
 class TestVerifyAllFilesNotUnderSingleDir:
@@ -648,6 +655,23 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
                 ),
                 id="normalized-with-grant-act",
             ),
+            pytest.param(
+                (
+                    {
+                        "file": "objects/reports/summary.pdf",
+                        "basis": "policy",
+                        "grant_act": "ß",
+                        "grant_restriction": "allow",
+                    },
+                    {
+                        "file": "objects/reports/summary.pdf",
+                        "basis": "policy",
+                        "grant_act": "ss",
+                        "grant_restriction": "allow",
+                    },
+                ),
+                id="importer-unicode-normalization",
+            ),
         ],
     )
     def test_rejects_duplicate_importer_combinations(self, rows):
@@ -682,6 +706,59 @@ objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
             rights_metadata=rights_metadata,
             file_listing=self.file_listing,
         )
+
+    def test_csv_parser_errors_are_verification_failures(self):
+        rights_metadata = (
+            "file,basis,note\n"
+            "objects/reports/summary.pdf,policy,"
+            f"{'a' * 131_073}\n"
+        )
+
+        with pytest.raises(
+            VerificationFailure,
+            match="Line 2 of your rights.csv could not be read as CSV",
+        ) as err:
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+        assert isinstance(err.value.__cause__, csv.Error)
+
+    @pytest.mark.parametrize(
+        "rights_metadata, line_number, missing_value",
+        [
+            pytest.param(
+                "file,basis,note\nobjects/reports/summary.pdf,policy\n",
+                2,
+                "note",
+                id="ordinary-row",
+            ),
+            pytest.param(
+                'file,basis,note\nobjects/reports/summary.pdf,policy,"First\n'
+                'line"\nobjects/reports/summary.pdf,policy\n',
+                4,
+                "note",
+                id="after-multiline-row",
+            ),
+        ],
+    )
+    def test_rejects_rows_with_missing_trailing_values(
+        self,
+        rights_metadata,
+        line_number,
+        missing_value,
+    ):
+        with pytest.raises(
+            VerificationFailure,
+            match=f"Line {line_number} of your rights.csv has fewer values",
+        ) as err:
+            verify_rights_csv_is_valid(
+                rights_metadata=rights_metadata,
+                file_listing=self.file_listing,
+            )
+
+        assert f"Missing values: {missing_value}." in str(err.value)
 
     @pytest.mark.parametrize(
         "rights_metadata, line_number",


### PR DESCRIPTION
## What does this change?

Validates optional `metadata/rights.csv` files before starting an Archivematica transfer, and documents the accepted format.

Fixes #113.

## How to test

1. Create and upload a transfer ZIP containing `metadata/metadata.csv` and an invalid `metadata/rights.csv` - for example, omit the required `basis` column.

2. Check the transfer-source S3 bucket. A `*.failed.*.log` file should be created beside the uploaded ZIP, explaining the format error, and no transfer should start.

3. Upload a ZIP with a valid `rights.csv`, for example:

    ```csv
    file,basis,status,jurisdiction,grant_act,grant_restriction
    objects/reports/summary.pdf,copyright,copyrighted,GB,disseminate,disallow
    ```

4. Confirm that the transfer starts normally and a `*.success.*.log` file is created.

## How can we measure success?

Malformed rights CSVs produce a `.failed.*.log` beside the uploaded ZIP instead of failing later in Archivematica.

## Have we considered potential risks?

Valid rights CSVs are unaffected. Invalid files now block transfer initiation; the S3 failure log explains the required correction.

