### PR TITLE
Exclude Python caches from Lambda packages

### DIFF
--- a/terraform/modules/stack/lambda/lambda_function.tf
+++ b/terraform/modules/stack/lambda/lambda_function.tf
@@ -2,6 +2,12 @@ data "archive_file" "deployment_package" {
   type        = "zip"
   source_dir  = var.source_dir
   output_path = "${var.name}.zip"
+
+  excludes = [
+    "**/__pycache__/**",
+    "**/*.pyc",
+    "**/*.pyo",
+  ]
 }
 
 module "lambda_function" {


### PR DESCRIPTION
## What does this change?

Excludes `__pycache__`, `.pyc`, and `.pyo` files when Terraform packages the Python Lambdas.

These files are generated locally and are not part of the reviewed source. Including them makes Lambda packages depend on which Python versions or tests have run in a developer's checkout. This could lead to packages containing bytecode from different Python versions.

Fixes #200.

## How to test

I generated all three packages locally using an isolated `archive_file` configuration with its backend disabled:

```console
terraform init -backend=false
terraform apply
```

I then checked their contents:

```console
unzip -Z1 lambda.zip | rg '(^|/)__pycache__/|\.py[co]$'
```

The command produced no matches. The ZIPs contained the expected source files and assets.

## How can we measure success?

Lambda packages generated from the same source remain unaffected by locally generated Python caches.

## Have we considered potential risks?

Low risk. Python source files remain in the packages and Lambda compiles them when needed. AWS recommends excluding locally generated `__pycache__` files.