### PR TITLE
Run the transfer_monitor tests in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,12 @@ steps:
   - wait
 
   - label: ":python: s3_start_transfer tests"
-    command: .buildkite/scripts/run_s3_start_transfer_tests.sh
+    command: .buildkite/scripts/run_lambda_tests.sh s3_start_transfer
+    agents:
+      queue: "scala"
+
+  - label: ":python: transfer_monitor tests"
+    command: .buildkite/scripts/run_lambda_tests.sh transfer_monitor
     agents:
       queue: "scala"
 

--- a/.buildkite/scripts/run_lambda_tests.sh
+++ b/.buildkite/scripts/run_lambda_tests.sh
@@ -1,28 +1,32 @@
 #!/usr/bin/env bash
+# Runs the test suite for one of the Lambdas, e.g. run_lambda_tests.sh transfer_monitor
 
 set -o errexit
 set -o nounset
 set -o pipefail
+
+LAMBDA="$1"
 
 ROOT=$(git rev-parse --show-toplevel)
 PYTHON_VERSION=$(< "$ROOT/.python-version")
 UV_IMAGE="ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie"
 
 docker run --rm \
-  --volume "$ROOT/lambdas/s3_start_transfer:/workspace:ro" \
+  --volume "$ROOT/lambdas/$LAMBDA:/workspace:ro" \
   --workdir /workspace \
-  --env COVERAGE_FILE=/tmp/s3_start_transfer.coverage \
+  --env LAMBDA="$LAMBDA" \
+  --env COVERAGE_FILE="/tmp/$LAMBDA.coverage" \
   --env PYTHON_VERSION="$PYTHON_VERSION" \
   --env PYTHONDONTWRITEBYTECODE=1 \
   --env UV_PYTHON_DOWNLOADS=never \
   --entrypoint /bin/bash \
   "$UV_IMAGE" \
   -e -c '
-    uv venv --python "$PYTHON_VERSION" /tmp/s3_start_transfer_venv
+    uv venv --python "$PYTHON_VERSION" "/tmp/${LAMBDA}_venv"
     uv pip sync \
-      --python /tmp/s3_start_transfer_venv/bin/python \
+      --python "/tmp/${LAMBDA}_venv/bin/python" \
       test_requirements.txt
-    /tmp/s3_start_transfer_venv/bin/python \
+    "/tmp/${LAMBDA}_venv/bin/python" \
       -m coverage run -m pytest -p no:cacheprovider
-    /tmp/s3_start_transfer_venv/bin/python -m coverage report
+    "/tmp/${LAMBDA}_venv/bin/python" -m coverage report
   '

--- a/lambdas/transfer_monitor/.coveragerc
+++ b/lambdas/transfer_monitor/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+include =
+    src/*.py
+    tests/*.py
+
+[report]
+show_missing = true
+fail_under = 97
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:


### PR DESCRIPTION
## What does this change?

Runs the `transfer_monitor` Python tests in Buildkite, alongside the `s3_start_transfer` tests added in #198.

The `run_s3_start_transfer_tests.sh` script was already generic apart from the Lambda name, so it becomes `run_lambda_tests.sh <lambda>` and the pipeline calls it once per Lambda. Also adds a `.coveragerc` for `transfer_monitor` matching the `s3_start_transfer` one, with `fail_under` set to the current level (97% with branch coverage; the misses are small error/formatting branches) so coverage can't regress without demanding 100% up front.

Follows up #198, which noted the `transfer_monitor` suite from #185 wasn't wired in.

## How to test

Run:

```console
.buildkite/scripts/run_lambda_tests.sh transfer_monitor
.buildkite/scripts/run_lambda_tests.sh s3_start_transfer
```

The transfer_monitor suite passes (11 tests, 97% coverage) and the s3_start_transfer suite is unaffected (220 tests, 100% coverage).

## How can we measure success?

Buildkite fails when either Lambda's tests or coverage check fail.

## Have we considered potential risks?

Same profile as #198: one more `uv` container run per build. The coverage floor is pinned at today's number, so a PR that only adds covered code won't trip it.
