### PR TITLE
Set CONCURRENT_PACKAGES to 3

### DIFF
--- a/terraform/modules/stack/services.tf
+++ b/terraform/modules/stack/services.tf
@@ -91,6 +91,7 @@ module "mcp_server_service" {
     ARCHIVEMATICA_MCPSERVER_CLIENT_DATABASE = "MCP"
 
     ARCHIVEMATICA_MCPSERVER_MCPARCHIVEMATICASERVER = "${local.gearmand_hostname}:4730"
+    ARCHIVEMATICA_MCPSERVER_CONCURRENT_PACKAGES    = "3"
 
     # We don't enable indexing or search with Elasticsearch.  Data from the
     # storage service is indexed separately in the reporting cluster.


### PR DESCRIPTION
## What does this change?

Sets `ARCHIVEMATICA_MCPSERVER_CONCURRENT_PACKAGES=3` for MCPServer.

Transfer-source retrieval now runs as workflow work, so this caps concurrent S3-to-processing-directory copies and reduces the risk of saturating the Storage Service, as described in [#176](https://github.com/wellcomecollection/archivematica-infrastructure/issues/176).

## How to test

Apply the Terraform change, then submit four or more transfers concurrently.

Confirm no more than three are actively retrieving at once; additional packages should remain queued until capacity is available. This should be observable in the Dashboard.

## How can we measure success?

The Storage Service should no longer be saturated by a burst of transfer-source copies, and Archivematica should continue to process other work and serve dashboard requests.

## Have we considered potential risks?

This deliberately reduces peak transfer throughput: excess packages wait in the queue.

Three concurrent packages and four Storage Service Gunicorn workers should leave capacity for normal web/API requests. In theory, a single gevent worker can handle concurrent I/O-bound requests; in practice, copy work may include blocking or otherwise non-cooperative operations that do not yield to the gevent loop. Multiple workers provide isolation in that case.
